### PR TITLE
Changed cli feature 'new's usage to match actual usage

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,7 +42,7 @@ func NewApp( //nolint:funlen
 			},
 			{
 				Name:  "new",
-				Usage: "Get current Nevalang version",
+				Usage: "Create new nevalang project",
 				Args:  true,
 				Action: func(cCtx *cli.Context) error {
 					if path := cCtx.Args().First(); path != "" {


### PR DESCRIPTION
Cli had 'new' as 'Get current nevalang version' instead of actual usage