### PR TITLE
fix(irgen): sort port addrs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -205,6 +205,15 @@
       "cwd": "${workspaceFolder}/examples",
       "args": ["run", "11_99_bottles"]
     },
+    {
+      "name": "Neva CLI 113",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/neva",
+      "cwd": "${workspaceFolder}/examples",
+      "args": ["run", "13_subtract"]
+    },
     // run (e2e tests)
     {
       "name": "E2E struct_selector_on_port_addr",

--- a/internal/compiler/irgen/network_test.go
+++ b/internal/compiler/irgen/network_test.go
@@ -1,6 +1,11 @@
 package irgen
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/nevalang/neva/internal/runtime/ir"
+	"github.com/stretchr/testify/require"
+)
 
 func Test_joinNodePath(t *testing.T) {
 	type args struct {
@@ -26,6 +31,42 @@ func Test_joinNodePath(t *testing.T) {
 			if got := joinNodePath(tt.args.nodePath, tt.args.nodeName); got != tt.want {
 				t.Errorf("joinNodePath() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_sortPortAddrs(t *testing.T) {
+	tests := []struct {
+		name  string
+		addrs []ir.PortAddr
+		want  []ir.PortAddr
+	}{
+		{
+			name: "messed up order",
+			addrs: []ir.PortAddr{
+				{Path: "b", Port: "A", Idx: 1},
+				{Path: "b", Port: "A", Idx: 0},
+				{Path: "a", Port: "B", Idx: 0},
+				{Path: "a", Port: "B", Idx: 1},
+				{Path: "a", Port: "A", Idx: 2},
+				{Path: "a", Port: "A", Idx: 1},
+				{Path: "a", Port: "A", Idx: 0},
+			},
+			want: []ir.PortAddr{
+				{Path: "a", Port: "A", Idx: 0},
+				{Path: "a", Port: "A", Idx: 1},
+				{Path: "a", Port: "A", Idx: 2},
+				{Path: "a", Port: "B", Idx: 0},
+				{Path: "a", Port: "B", Idx: 1},
+				{Path: "b", Port: "A", Idx: 0},
+				{Path: "b", Port: "A", Idx: 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortPortAddrs(tt.addrs)
+			require.Equal(t, tt.want, tt.addrs)
 		})
 	}
 }

--- a/internal/runtime/ir/ir.go
+++ b/internal/runtime/ir/ir.go
@@ -40,8 +40,8 @@ type FuncCall struct {
 
 // FuncIO represents the input/output ports of a function.
 type FuncIO struct {
-	In  []PortAddr
-	Out []PortAddr
+	In  []PortAddr // Must be ordered by path -> port -> idx
+	Out []PortAddr // Must be ordered by path -> port -> idx
 }
 
 // Msg represents a message.


### PR DESCRIPTION
For func-call IO so adapter and backend correctly maps channels onto them and components with array-ports where order matters don't break unpredictably.