### PR TITLE
CLI: Add support for new "json" build target

### DIFF
--- a/cmd/neva/main.go
+++ b/cmd/neva/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nevalang/neva/internal/compiler/backend/golang"
 	"github.com/nevalang/neva/internal/compiler/backend/golang/native"
 	"github.com/nevalang/neva/internal/compiler/backend/golang/wasm"
+	"github.com/nevalang/neva/internal/compiler/backend/json"
 	"github.com/nevalang/neva/internal/compiler/desugarer"
 	"github.com/nevalang/neva/internal/compiler/irgen"
 	"github.com/nevalang/neva/internal/compiler/parser"
@@ -78,6 +79,15 @@ func main() { //nolint:funlen
 		),
 	)
 
+	jsonCompiler := compiler.New(
+		pkgMngr,
+		prsr,
+		desugarer,
+		analyzer,
+		irgen,
+		json.NewBackend(),
+	)
+
 	// command-line app that can compile and interpret neva code
 	app := cli.NewApp(
 		wd,
@@ -85,6 +95,7 @@ func main() { //nolint:funlen
 		goCompiler,
 		nativeCompiler,
 		wasmCompiler,
+		jsonCompiler,
 	)
 
 	// run CLI app

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,6 +22,7 @@ func NewApp( //nolint:funlen
 	goc compiler.Compiler,
 	nativec compiler.Compiler,
 	wasmc compiler.Compiler,
+	jsonc compiler.Compiler,
 ) *cli.App {
 	var (
 		target string
@@ -115,7 +116,7 @@ func NewApp( //nolint:funlen
 						Destination: &target,
 						Action: func(ctx *cli.Context, s string) error {
 							switch s {
-							case "go", "wasm", "native":
+							case "go", "wasm", "native", "json":
 							default:
 								return fmt.Errorf("Unknown target %s", s)
 							}
@@ -136,6 +137,10 @@ func NewApp( //nolint:funlen
 						)
 					case "wasm":
 						return wasmc.Compile(
+							workdir, dirFromArg, workdir,
+						)
+					case "json":
+						return jsonc.Compile(
 							workdir, dirFromArg, workdir,
 						)
 					default:

--- a/internal/compiler/backend/json/backend.go
+++ b/internal/compiler/backend/json/backend.go
@@ -1,0 +1,26 @@
+package json
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/nevalang/neva/internal/runtime/ir"
+)
+
+type Backend struct{}
+
+func NewBackend() Backend {
+	return Backend{}
+}
+
+func (b Backend) Emit(dst string, prog *ir.Program) error {
+	outFile := filepath.Join(dst, "program.json")
+	f, err := os.OpenFile(outFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	e := json.NewEncoder(f)
+	return e.Encode(prog)
+}

--- a/internal/runtime/ir/ir.go
+++ b/internal/runtime/ir/ir.go
@@ -2,57 +2,57 @@ package ir
 
 // Program represents the main structure containing ports, connections, and funcs.
 type Program struct {
-	Ports       []PortInfo
-	Connections []Connection
-	Funcs       []FuncCall
+	Ports       []PortInfo   `json:"ports,omitempty"`
+	Connections []Connection `json:"connections,omitempty"`
+	Funcs       []FuncCall   `json:"funcs,omitempty"`
 }
 
 // PortInfo contains information about each port.
 type PortInfo struct {
-	PortAddr PortAddr
-	BufSize  uint32
+	PortAddr PortAddr `json:"port_addr,omitempty"`
+	BufSize  uint32   `json:"buf_size,omitempty"`
 }
 
 // PortAddr represents the address of a port.
 type PortAddr struct {
-	Path string
-	Port string
-	Idx  uint32
+	Path string `json:"path,omitempty"`
+	Port string `json:"port,omitempty"`
+	Idx  uint32 `json:"index,omitempty"`
 }
 
 // Connection represents connections between ports.
 type Connection struct {
-	SenderSide    PortAddr
-	ReceiverSides []ReceiverConnectionSide
+	SenderSide    PortAddr                 `json:"sender_side,omitempty"`
+	ReceiverSides []ReceiverConnectionSide `json:"receiver_sides,omitempty"`
 }
 
 // ReceiverConnectionSide represents the receiver side of a connection.
 type ReceiverConnectionSide struct {
-	PortAddr PortAddr
+	PortAddr PortAddr `json:"port_addr,omitempty"`
 }
 
 // FuncCall represents a function within the program.
 type FuncCall struct {
-	Ref string
-	IO  FuncIO
-	Msg *Msg
+	Ref string `json:"ref,omitempty"`
+	IO  FuncIO `json:"io,omitempty"`
+	Msg *Msg   `json:"msg,omitempty"`
 }
 
 // FuncIO represents the input/output ports of a function.
 type FuncIO struct {
-	In  []PortAddr // Must be ordered by path -> port -> idx
-	Out []PortAddr // Must be ordered by path -> port -> idx
+	In  []PortAddr `json:"in,omitempty"`  // Must be ordered by path -> port -> idx
+	Out []PortAddr `json:"out,omitempty"` // Must be ordered by path -> port -> idx
 }
 
 // Msg represents a message.
 type Msg struct {
-	Type  MsgType
-	Bool  bool
-	Int   int64
-	Float float64
-	Str   string
-	List  []Msg
-	Map   map[string]Msg
+	Type  MsgType        `json:"-"`
+	Bool  bool           `json:"bool,omitempty"`
+	Int   int64          `json:"int,omitempty"`
+	Float float64        `json:"float,omitempty"`
+	Str   string         `json:"str,omitempty"`
+	List  []Msg          `json:"list,omitempty"`
+	Map   map[string]Msg `json:"map,omitempty"`
 }
 
 // MsgType is an enumeration of message types.


### PR DESCRIPTION
Allows easily debugging the IR using JSON.

Example usage:

```
$ go run ../cmd/neva/ build --target json 0_do_nothing/without_net_kw
$ cat program.json
{
  "ports": [
    {
      "port_addr": {
        "path": "in",
        "port": "start"
      }
    },
    {
      "port_addr": {
        "path": "out",
        "port": "stop"
      }
    }
  ],
  "connections": [
    {
      "sender_side": {
        "path": "in",
        "port": "start"
      },
      "receiver_sides": [
        {
          "port_addr": {
            "path": "out",
            "port": "stop"
          }
        }
      ]
    }
  ]
}
```