### PR TITLE
DOT: Add Graphviz renderer backend

### DIFF
--- a/cmd/neva/main.go
+++ b/cmd/neva/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nevalang/neva/internal/cli"
 	"github.com/nevalang/neva/internal/compiler"
 	"github.com/nevalang/neva/internal/compiler/analyzer"
+	"github.com/nevalang/neva/internal/compiler/backend/dot"
 	"github.com/nevalang/neva/internal/compiler/backend/golang"
 	"github.com/nevalang/neva/internal/compiler/backend/golang/native"
 	"github.com/nevalang/neva/internal/compiler/backend/golang/wasm"
@@ -88,6 +89,15 @@ func main() { //nolint:funlen
 		json.NewBackend(),
 	)
 
+	dotCompiler := compiler.New(
+		pkgMngr,
+		prsr,
+		desugarer,
+		analyzer,
+		irgen,
+		dot.NewBackend(),
+	)
+
 	// command-line app that can compile and interpret neva code
 	app := cli.NewApp(
 		wd,
@@ -96,6 +106,7 @@ func main() { //nolint:funlen
 		nativeCompiler,
 		wasmCompiler,
 		jsonCompiler,
+		dotCompiler,
 	)
 
 	// run CLI app

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,6 +23,7 @@ func NewApp( //nolint:funlen
 	nativec compiler.Compiler,
 	wasmc compiler.Compiler,
 	jsonc compiler.Compiler,
+	dotc compiler.Compiler,
 ) *cli.App {
 	var (
 		target string
@@ -116,7 +117,7 @@ func NewApp( //nolint:funlen
 						Destination: &target,
 						Action: func(ctx *cli.Context, s string) error {
 							switch s {
-							case "go", "wasm", "native", "json":
+							case "go", "wasm", "native", "json", "dot":
 							default:
 								return fmt.Errorf("Unknown target %s", s)
 							}
@@ -141,6 +142,10 @@ func NewApp( //nolint:funlen
 						)
 					case "json":
 						return jsonc.Compile(
+							workdir, dirFromArg, workdir,
+						)
+					case "dot":
+						return dotc.Compile(
 							workdir, dirFromArg, workdir,
 						)
 					default:

--- a/internal/compiler/backend/dot/backend.go
+++ b/internal/compiler/backend/dot/backend.go
@@ -1,0 +1,31 @@
+package dot
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/nevalang/neva/internal/runtime/graphviz"
+	"github.com/nevalang/neva/internal/runtime/ir"
+)
+
+type Backend struct{}
+
+func NewBackend() Backend {
+	return Backend{}
+}
+
+func (b Backend) Emit(dst string, prog *ir.Program) error {
+	outFile := filepath.Join(dst, "program.dot")
+	f, err := os.OpenFile(outFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	var cb graphviz.ClusterBuilder
+	for _, e := range prog.Connections {
+		for _, r := range e.ReceiverSides {
+			cb.InsertEdge(e.SenderSide, r.PortAddr)
+		}
+	}
+	return cb.Build(f)
+}

--- a/internal/compiler/backend/dot/backend.go
+++ b/internal/compiler/backend/dot/backend.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/nevalang/neva/internal/runtime/graphviz"
 	"github.com/nevalang/neva/internal/runtime/ir"
 )
 
@@ -21,7 +20,7 @@ func (b Backend) Emit(dst string, prog *ir.Program) error {
 		return err
 	}
 	defer f.Close()
-	var cb graphviz.ClusterBuilder
+	var cb ClusterBuilder
 	for _, e := range prog.Connections {
 		for _, r := range e.ReceiverSides {
 			cb.InsertEdge(e.SenderSide, r.PortAddr)

--- a/internal/runtime/graphviz/graphviz.go
+++ b/internal/runtime/graphviz/graphviz.go
@@ -1,0 +1,127 @@
+package graphviz
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nevalang/neva/internal/runtime/ir"
+)
+
+type Node struct {
+	ir.PortAddr
+}
+
+func (n Node) Label() string { return n.Port }
+
+func (n Node) Name() string {
+	path := strings.TrimSuffix(strings.TrimSuffix(n.Path, "/in"), "/out")
+	return fmt.Sprint(path, ":", n.Port)
+}
+
+type Edge struct {
+	Send Node
+	Recv Node
+}
+
+func (e Edge) Label() string {
+	switch send, recv := e.Send.Idx, e.Recv.Idx; {
+	case send == 0 && recv == 0:
+		return ""
+	default:
+		return fmt.Sprintf("%d->%d", send, recv)
+	}
+}
+
+type Cluster struct {
+	Index    int
+	Prefix   string
+	Nodes    map[Node]struct{}
+	Clusters map[string]*Cluster
+}
+
+func (c *Cluster) Label() string {
+	i := strings.LastIndexByte(c.Prefix, '/')
+	if i == -1 {
+		return c.Prefix
+	}
+	return c.Prefix[i+1:]
+}
+
+type ClusterBuilder struct {
+	Main   *Cluster
+	Edges  []Edge
+	nextId int
+}
+
+func (b *ClusterBuilder) insertClusterNode(addr ir.PortAddr) {
+	if b.Main == nil {
+		cluster := &Cluster{}
+		b.Main = cluster
+		b.nextId++
+	}
+	cluster := b.Main
+	prefix := ""
+	for path := addr.Path; ; {
+		before, after, found := strings.Cut(path, "/")
+		if !found {
+			if cluster.Nodes == nil {
+				cluster.Nodes = map[Node]struct{}{}
+			}
+			cluster.Nodes[Node{addr}] = struct{}{}
+			break
+		}
+		if prefix == "" {
+			prefix = before
+		} else {
+			prefix = prefix + "/" + before
+		}
+		next := cluster.Clusters[before]
+		if next == nil {
+			if cluster.Clusters == nil {
+				cluster.Clusters = map[string]*Cluster{}
+			}
+			next = &Cluster{Index: b.nextId, Prefix: prefix}
+			cluster.Clusters[before] = next
+			b.nextId++
+		}
+		path = after
+		cluster = next
+	}
+}
+
+func (b *ClusterBuilder) InsertEdge(send, recv ir.PortAddr) {
+	b.insertClusterNode(send)
+	b.insertClusterNode(recv)
+	b.Edges = append(b.Edges, Edge{Send: Node{send}, Recv: Node{recv}})
+}
+
+func (b *ClusterBuilder) Build(w io.Writer) error {
+	fmt.Fprintln(w, "digraph G {")
+	recursiveBuild(w, "  ", b.Main)
+	for _, e := range b.Edges {
+		fmt.Fprintf(w, "  %q -> %q", e.Send.Name(), e.Recv.Name())
+		if label := e.Label(); label != "" {
+			fmt.Fprintf(w, "[label = %q;]", label)
+		}
+		fmt.Fprintln(w, ";")
+	}
+	fmt.Fprintln(w, "}")
+	return nil
+}
+
+func recursiveBuild(w io.Writer, indent string, c *Cluster) error {
+	fprintlnIndent := func(f string, a ...any) {
+		fmt.Fprintln(w, indent, fmt.Sprintf(f, a...))
+	}
+	fprintlnIndent("subgraph cluster_%d {", c.Index)
+	fprintlnIndent("  label = \"%s\";", c.Label())
+	for n := range c.Nodes {
+		fprintlnIndent("  %q [label = \"%s\";];", n.Name(), n.Label())
+	}
+	for _, sub := range c.Clusters {
+		recursiveBuild(w, indent+"  ", sub)
+	}
+	fprintlnIndent("}")
+	return nil
+}


### PR DESCRIPTION
Allows easy visualization of IR

Example:

```
$ go run ../cmd/neva/ build --target dot 2_hello_world/5_with_implicit_any
$ cat program.dot
digraph G {
   subgraph cluster_0 {
     label = "";
     "in:start" [label = "start";];
     "out:stop" [label = "stop";];
     subgraph cluster_1 {
       label = "virtual_emitter_23";
       "virtual_emitter_23:msg" [label = "msg";];
     }
     subgraph cluster_2 {
       label = "virtual_blocker_14";
       "virtual_blocker_14:data" [label = "data";];
       "virtual_blocker_14:data" [label = "data";];
       "virtual_blocker_14:sig" [label = "sig";];
     }
     subgraph cluster_3 {
       label = "printer";
       "printer:data" [label = "data";];
       "printer:sig" [label = "sig";];
     }
   }
  "virtual_emitter_23:msg" -> "virtual_blocker_14:data";
  "virtual_blocker_14:data" -> "printer:data";
  "in:start" -> "virtual_blocker_14:sig";
  "printer:sig" -> "out:stop";
}
```
Visualizing the graph:

Consider using a VSCode plugin to preview the DOT graph or using an online tool such as https://dreampuf.github.io/GraphvizOnline/ ([example](https://dreampuf.github.io/GraphvizOnline/?compressed=CYSw5gTghgDgFgAgOIIN4CgFYM4FcBGksiAxgDa7YAuAphAPoAMamWWZU%2BNZCAvAgCIBAblZsBIAHYAualAhUBCANocuPfgLkKRAXVFssAgPa4qsqsZhLVnbn0HUreg4byFo8BOUq0GARhZDNjV7TQA3EAVcKDJ6GgBbECo-egAmAGYRMUMBSOjY%2BKSUunSM6QTsMBtQjUFK6uF9HIQAXxb3Ii8falK0oOCEWoc8qKoYuPwyYxIAa1L-ABZswcF88cKpmfmAxelgKCooGrs6gQOjlxajdYn6LbmFvYvjlWHNF6vV0YLJ6cfdrJwCd1CNsMCmq42O1gp1PKQKL0GBkBsF3oIYBApH4VoMBJjsXR9odXrZQR8SV88QTJH4gdU3qcwRDmsEYVh2T8NnFEslUpkKlUlABaAB8azGdweO3oS2Jl1cXKl-xlcs%2BCDFGKxtKJn0VUgs8kUGvFSs2Kqe9Nx%2BO1dPBDM1JjMFmcolaQA))