### PR TITLE
Runtime: Add Decode, Encode for native Msg types

### DIFF
--- a/internal/runtime/msg.go
+++ b/internal/runtime/msg.go
@@ -53,6 +53,16 @@ type IntMsg struct {
 func (msg IntMsg) Type() MsgType  { return IntMsgType }
 func (msg IntMsg) Int() int64     { return msg.v }
 func (msg IntMsg) String() string { return strconv.Itoa(int(msg.v)) }
+func (i *IntMsg) Reset()          { i.v = 0 }
+func (i *IntMsg) Decode(msg Msg) bool {
+	i.Reset()
+	if msg == nil || msg.Type() != IntMsgType {
+		return false
+	}
+	i.v = msg.Int()
+	return true
+}
+func (msg IntMsg) Encode() Msg { return msg }
 
 func NewIntMsg(n int64) IntMsg {
 	return IntMsg{
@@ -71,6 +81,16 @@ type FloatMsg struct {
 func (msg FloatMsg) Type() MsgType  { return FloatMsgType }
 func (msg FloatMsg) Float() float64 { return msg.v }
 func (msg FloatMsg) String() string { return fmt.Sprint(msg.v) }
+func (f *FloatMsg) Reset()          { f.v = 0 }
+func (f *FloatMsg) Decode(msg Msg) bool {
+	f.Reset()
+	if msg == nil || msg.Type() != FloatMsgType {
+		return false
+	}
+	f.v = msg.Float()
+	return true
+}
+func (msg FloatMsg) Encode() Msg { return msg }
 
 func NewFloatMsg(n float64) FloatMsg {
 	return FloatMsg{
@@ -89,6 +109,16 @@ type StrMsg struct {
 func (msg StrMsg) Type() MsgType  { return StrMsgType }
 func (msg StrMsg) Str() string    { return msg.v }
 func (msg StrMsg) String() string { return msg.v }
+func (s *StrMsg) Reset()          { s.v = "" }
+func (s *StrMsg) Decode(msg Msg) bool {
+	s.Reset()
+	if msg == nil || msg.Type() != StrMsgType {
+		return false
+	}
+	s.v = msg.Str()
+	return true
+}
+func (msg StrMsg) Encode() Msg { return msg }
 
 func NewStrMsg(s string) StrMsg {
 	return StrMsg{
@@ -107,6 +137,16 @@ type BoolMsg struct {
 func (msg BoolMsg) Type() MsgType  { return BoolMsgType }
 func (msg BoolMsg) Bool() bool     { return msg.v }
 func (msg BoolMsg) String() string { return strconv.FormatBool(msg.v) }
+func (b *BoolMsg) Reset()          { b.v = false }
+func (b *BoolMsg) Decode(msg Msg) bool {
+	b.Reset()
+	if msg == nil || msg.Type() != BoolMsgType {
+		return false
+	}
+	b.v = msg.Bool()
+	return true
+}
+func (msg BoolMsg) Encode() Msg { return msg }
 
 func NewBoolMsg(b bool) BoolMsg {
 	return BoolMsg{
@@ -124,6 +164,16 @@ type ListMsg struct {
 func (msg ListMsg) Type() MsgType  { return ListMsgType }
 func (msg ListMsg) List() []Msg    { return msg.v }
 func (msg ListMsg) String() string { return fmt.Sprint(msg.v) }
+func (l *ListMsg) Reset()          { l.v = nil }
+func (l *ListMsg) Decode(msg Msg) bool {
+	l.Reset()
+	if msg == nil || msg.Type() != ListMsgType {
+		return false
+	}
+	l.v = msg.List()
+	return true
+}
+func (msg ListMsg) Encode() Msg { return msg }
 
 func NewListMsg(v ...Msg) ListMsg {
 	return ListMsg{
@@ -141,6 +191,16 @@ type MapMsg struct {
 func (msg MapMsg) Type() MsgType       { return MapMsgType }
 func (msg MapMsg) Map() map[string]Msg { return msg.v }
 func (msg MapMsg) String() string      { return fmt.Sprint(msg.v) }
+func (m *MapMsg) Reset()               { m.v = nil }
+func (m *MapMsg) Decode(msg Msg) bool {
+	m.Reset()
+	if msg == nil || msg.Type() != MapMsgType {
+		return false
+	}
+	m.v = msg.Map()
+	return true
+}
+func (msg MapMsg) Encode() Msg { return msg }
 
 func NewMapMsg(m map[string]Msg) MapMsg {
 	return MapMsg{


### PR DESCRIPTION
This makes the `runtime.Msg` native types easily embeddable in other structs so we can create compound struct types more easily.

Still TBD how/if to make `Encode` and `Decode` on structs more economical.

Example usage:

```go

type rgbaMsg struct {
	r runtime.IntMsg
	g runtime.IntMsg
	b runtime.IntMsg
	a runtime.IntMsg
}

func (c *rgbaMsg) Reset() { *c = rgbaMsg{} }
func (c *rgbaMsg) Decode(msg runtime.Msg) bool {
	c.reset()
	if msg == nil {
		return false
	}
	m := msg.Map()
	if m == nil {
		return false
	}
	return c.r.Decode(m["r"]) &&
		c.r.Decode(m["g"]) &&
		c.r.Decode(m["b"]) &&
		c.r.Decode(m["a"])
}
func (c *rgbaMsg) Encode() runtime.Msg {
	return runtime.NewMapMsg(map[string]runtime.Msg{
		"r": c.r,
		"g": c.g,
		"b": c.b,
		"a": c.a,
	})
}
```

For now this helps with internal dev and making runtime funcs. In the future, such code can be generated from the stdlib or user code libraries facilitating interop with Go.