### PR TITLE
reimplemented iter

### DIFF
--- a/examples/iterate_over_list/e2e_test.go
+++ b/examples/iterate_over_list/e2e_test.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	err := os.Chdir("..")
+	require.NoError(t, err)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(wd)
+
+	cmd := exec.Command("neva", "run", "iterate_over_list")
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"50\n30\n20\n100\n",
+		string(out),
+	)
+
+	require.Equal(t, 0, cmd.ProcessState.ExitCode())
+}

--- a/examples/iterate_over_list/main.neva
+++ b/examples/iterate_over_list/main.neva
@@ -1,0 +1,17 @@
+const l list<int> = [50, 30, 20, 100]
+
+component Main(start any) (stop any) {
+    nodes {
+        print Println<int>
+        iter Iter<int>
+        unw Unwrap<int>
+        del Del
+    }
+    net {
+        :start -> ($l -> iter:lst)
+        iter:res -> unw:data
+        unw:some -> print:data
+        print:sig -> del:msg
+        unw:none -> :stop
+    }
+}

--- a/internal/runtime/funcs/list_iter.go
+++ b/internal/runtime/funcs/list_iter.go
@@ -1,0 +1,44 @@
+package funcs
+
+import (
+	"context"
+	"github.com/nevalang/neva/internal/runtime"
+)
+
+type list_iter struct{}
+
+func (c list_iter) Create(io runtime.FuncIO, _ runtime.Msg) (func(ctx context.Context), error) {
+	lstIn, err := io.In.Port("lst")
+	if err != nil {
+		return nil, err
+	}
+	outport, err := io.Out.Port("res")
+	if err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context) {
+		for {
+			select {
+			case data, ok := <-lstIn:
+				if !ok {
+					return // lstIn channel closed
+				}
+				for i := 0; i < len(data.List()); i++ {
+					select {
+					case <-ctx.Done():
+						return
+					case outport <- data.List()[i]:
+					}
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case outport <- nil:
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}, nil
+}

--- a/internal/runtime/funcs/registry.go
+++ b/internal/runtime/funcs/registry.go
@@ -37,6 +37,7 @@ func CreatorRegistry() map[string]runtime.FuncCreator {
 		//list
 		"index":       index{},
 		"list_len":    listlen{},
+		"list_iter":   list_iter{},
 		"list_push":   listPush{},
 		"int_sort":    listSortInt{},
 		"float_sort":  listSortFloat{},

--- a/std/builtin/collections.neva
+++ b/std/builtin/collections.neva
@@ -31,4 +31,7 @@ component {
 
     #extern(slice)
     pub Slice<T string | list<any>>(data T, from int, to int) (res T, err error)
+
+    #extern(list_iter)
+    pub Iter<T any> (lst list<T>) (res maybe<T>)
 }


### PR DESCRIPTION
Finally finished iter, which gives us new capabilities when it comes to using lists. A nice example of using iter looks like this,


**Print each character on a new line in Neva using Iter**
```const s string = 'Flow programming is so cool'

component Main(start any) (stop any) {
    nodes {print Println<string>,iter Iter<string>,unw Unwrap<string>,del Del,split Split}
    net {
        :start -> [
        			($s -> split:data),
        			('' -> split:delim)
        		]
        split:res -> iter-> unw:data
        unw:some -> print -> del
        unw:none -> :stop
    }
}
```
