### PR TITLE
Unwrap Component 2.0

### DIFF
--- a/examples/iterate_over_list/e2e_test.go
+++ b/examples/iterate_over_list/e2e_test.go
@@ -22,11 +22,7 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		`{"data": 50, "idx": 0, "last": false}
-{"data": 30, "idx": 1, "last": false}
-{"data": 20, "idx": 2, "last": false}
-{"data": 100, "idx": 3, "last": true}
-`,
+		"50\n30\n20\n100\n",
 		string(out),
 	)
 

--- a/examples/iterate_over_list/main.neva
+++ b/examples/iterate_over_list/main.neva
@@ -1,8 +1,9 @@
 const lst list<int> = [50, 30, 20, 100]
 
 component Main(start) (stop) {
-    nodes { Println<stream<int>>, Iter<int>, Match<bool> }
-    :start -> ($lst -> iter -> println) 
-    println.last -> match:data
-    true -> match:case[0] -> :stop
+    nodes { Println<int>, Iter<int>,Unwrap<int>,Del}
+    :start -> ($lst -> iter -> unwrap)
+    unwrap:some -> println -> del
+    unwrap:none -> :stop
 }
+

--- a/internal/runtime/funcs/unwrap.go
+++ b/internal/runtime/funcs/unwrap.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"context"
 	"github.com/nevalang/neva/internal/runtime"
+	"time"
 )
 
 type unwrap struct{}
@@ -34,14 +35,11 @@ func (unwrap) Create(io runtime.FuncIO, _ runtime.Msg) (func(ctx context.Context
 			case dataMsg = <-dataIn:
 				item = dataMsg.Map()
 			}
+
 			if item["last"].Bool() {
-				select {
-				case someOut <- item["data"]:
-					noneOut <- runtime.NewMapMsg(nil)
-					return
-				case <-ctx.Done():
-					return
-				}
+				someOut <- item["data"]
+				time.Sleep(time.Millisecond * 1)
+				noneOut <- nil
 			} else {
 				select {
 				case <-ctx.Done():

--- a/std/builtin/core.neva
+++ b/std/builtin/core.neva
@@ -22,7 +22,7 @@ component {
     pub Match<T>(data T, [case] T) ([case] T, else T)
 
     #extern(unwrap)
-    pub Unwrap<T>(data maybe<T>) (some T, none struct{})
+    pub Unwrap<T>(data stream<T>) (some T, none struct{})
 
     #extern(stream_int_range)
     pub Range(from int, to int) (data stream<int>)


### PR DESCRIPTION
## A new and improved version of the original Unwrap

**Why?**
Before the new interface for streaming, neva's Iter was a simple and elegant language construct, however since v0.20.0 it has become ugly and quite unusable.

Before:
```const lst list<int> = [50, 30, 20, 100]

component Main(start) (stop) {
    nodes { Println<maybe<int>>, Iter<int>, Unwrap<int> }
    net {
        :start -> ($lst -> iter -> println -> unwrap)
        unwrap:none -> :stop
    }
}
```

After:
```
const lst list<int> = [50, 30, 20, 100]

component Main(start) (stop) {
    nodes { Println<stream<int>>, Iter<int>, Match<bool> }
    :start -> ($lst -> iter -> println) 
    println.last -> match:data
    true -> match:case[0] -> :stop
}
```

**Solution**
The solution was upgrading unwrap to a more modern implemnation which turns that same code into this.
```const lst list<int> = [50, 30, 20, 100]

component Main(start) (stop) {
    nodes { Println<int>, Iter<int>,Unwrap<int>,Del}
    :start -> ($lst -> iter -> unwrap)
    unwrap:some -> println -> del
    unwrap:none -> :stop
}

```

**Use case**

Heres how easy it is to print numbers from 1 too 99, now imagine how easy it becomes to rewrite the 99 bottles example
```
component Main(start) (stop) {
    nodes { Println<int> Unwrap<int>,Del,Range}
        :start -> [
            (1 -> range:from),
            (100 -> range:to)
        ]
    range -> unwrap
    unwrap:some -> println -> del
    unwrap:none -> :stop
}

```
