### PR TITLE
Sync: Add WaitGroup for counting lock use cases

### DIFF
--- a/examples/wait_group/e2e_test.go
+++ b/examples/wait_group/e2e_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	err := os.Chdir("..")
+	require.NoError(t, err)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(wd)
+
+	cmd := exec.Command("neva", "run", "wait_group")
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+
+	t.Log(string(out))
+	require.True(
+		t,
+		string(out) == "Hello\nWorld!\nNeva\n" ||
+			string(out) == "Hello\nNeva\nWorld!\n" ||
+			string(out) == "Neva\nHello\nWorld!\n" ||
+			string(out) == "Neva\nWorld!\nHello\n" ||
+			string(out) == "World!\nHello\nNeva\n" ||
+			string(out) == "World!\nNeva\nHello\n",
+	)
+
+	require.Equal(t, 0, cmd.ProcessState.ExitCode())
+}

--- a/examples/wait_group/main.neva
+++ b/examples/wait_group/main.neva
@@ -1,12 +1,12 @@
 import { sync }
 
 component Main(start) (stop) {
-  nodes { wg sync.WaitGroup, Println }
+  nodes { sync.Wg, Println }
   :start -> [
-    (3 -> wg),
-    ('Hello' -> println -> (-1 -> wg)),
-    ('Neva' -> println -> (-1 -> wg)),
-    ('World!' -> println -> (-1 -> wg))
+    (3 -> wg:count),
+    ('Hello' -> println -> (true -> wg:sig)),
+    ('Neva' -> println -> (true -> wg:sig)),
+    ('World!' -> println -> (true -> wg:sig))
   ]
   wg -> :stop
 }

--- a/examples/wait_group/main.neva
+++ b/examples/wait_group/main.neva
@@ -1,0 +1,12 @@
+import { sync }
+
+component Main(start) (stop) {
+  nodes { wg sync.WaitGroup, Println }
+  :start -> [
+    (3 -> wg),
+    ('Hello' -> println -> (-1 -> wg)),
+    ('Neva' -> println -> (-1 -> wg)),
+    ('World!' -> println -> (-1 -> wg))
+  ]
+  wg -> :stop
+}

--- a/internal/runtime/funcs/registry.go
+++ b/internal/runtime/funcs/registry.go
@@ -83,5 +83,8 @@ func CreatorRegistry() map[string]runtime.FuncCreator {
 		// image
 		"image_encode": imageEncode{},
 		"image_new":    imageNew{},
+
+		// sync
+		"wait_group": waitGroup{},
 	}
 }

--- a/internal/runtime/funcs/wait_group.go
+++ b/internal/runtime/funcs/wait_group.go
@@ -1,0 +1,88 @@
+package funcs
+
+import (
+	"context"
+	"sync"
+
+	"github.com/nevalang/neva/internal/runtime"
+)
+
+type waitGroup struct{}
+
+func (g waitGroup) Create(io runtime.FuncIO, _ runtime.Msg) (func(ctx context.Context), error) {
+	addIn, err := io.In.Port("add")
+	if err != nil {
+		return nil, err
+	}
+
+	sigOut, err := io.Out.Port("sig")
+	if err != nil {
+		return nil, err
+	}
+
+	return g.Handle(addIn, sigOut), nil
+}
+
+func (g waitGroup) Handle(
+	addIn,
+	sigOut chan runtime.Msg,
+) func(ctx context.Context) {
+	return func(ctx context.Context) {
+		var (
+			mu    sync.RWMutex
+			ready bool  // ready when we have received a nonnegative count, protected by mu.
+			count int64 // internal count, protected by mu.
+		)
+
+		reset := func() {
+			mu.Lock()
+			defer mu.Unlock()
+			ready = false
+			count = 0
+		}
+
+		add := func(n int64) {
+			mu.Lock()
+			defer mu.Unlock()
+			if n >= 0 {
+				ready = true
+			}
+			count += n
+		}
+
+		done := func() bool {
+			mu.RLock()
+			defer mu.RUnlock()
+			return ready && count <= 0
+		}
+
+		update := func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case n := <-addIn:
+					add(n.Int())
+				}
+			}
+		}
+		go update()
+
+		for {
+			if !done() {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case sigOut <- nil:
+				reset()
+			}
+		}
+	}
+}

--- a/std/sync/sync.neva
+++ b/std/sync/sync.neva
@@ -1,17 +1,18 @@
-// WaitGroup outputs a signal after its internal counter decreases to <= 0.
+// Wg implements a "wait group" which outputs a signal after the count decreases to 0 via sending to :sig.
 //
-// :add increases or decreases the value of the internal counter.
-// WaitGroup will not signal until it received at least one nonnegative value from :add.
+// Send to :count to set the initial counter.
+// Send to :sig to decrement the counter.
+// WaitGroup will not output a signal until it received at least :count.
 //
 // Example:
-//  nodes { wg WaitGroup }
-//  :start -> (2 -> wg:add)
-//  task1 -> (-1 -> wg:add)
-//  task2 -> (-1 -> wg:add)
+//  nodes { sync.Wg }
+//  :start -> (2 -> wg:count)
+//  task1 -> (true -> wg:sig)
+//  task2 -> (true -> wg:sig)
 //  wg -> :stop  // Signals after both tasks are done.
 //
 // Example:
-//  nodes { wg WaitGroup }
+//  nodes { sync.Wg }
 //  wg -> :stop  // Blocks forever.
 #extern(wait_group)
-pub component WaitGroup(add int) (sig any)
+pub component Wg(count int, sig any) (sig any)

--- a/std/sync/sync.neva
+++ b/std/sync/sync.neva
@@ -1,0 +1,17 @@
+// WaitGroup outputs a signal after its internal counter decreases to <= 0.
+//
+// :add increases or decreases the value of the internal counter.
+// WaitGroup will not signal until it received at least one nonnegative value from :add.
+//
+// Example:
+//  nodes { wg WaitGroup }
+//  :start -> (2 -> wg:add)
+//  task1 -> (-1 -> wg:add)
+//  task2 -> (-1 -> wg:add)
+//  wg -> :stop  // Signals after both tasks are done.
+//
+// Example:
+//  nodes { wg WaitGroup }
+//  wg -> :stop  // Blocks forever.
+#extern(wait_group)
+pub component WaitGroup(add int) (sig any)


### PR DESCRIPTION
Add example and e2e test

## On using Go's `sync.WaitGroup` internally

`WaitGroup` panics when the count gets below 0 so we have to be careful to take the count first, then take all the signals.

This may lead to panics in arithmetic use cases I.e. when passing `len(a)-len(b) -> wg; wg -> :done`. This is input dependent on the lengths of a and b. User needs to guard against this case.