### PR TITLE
fix: File lock not released properly

### DIFF
--- a/internal/builder/lock.go
+++ b/internal/builder/lock.go
@@ -23,10 +23,12 @@ func acquireLockFile() (release func(), err error) {
 		)
 		if err == nil {
 			return func() {
-				if err := os.Remove(filename); err != nil {
+				//must close first, then remove it.
+				if err := f.Close(); err != nil {
 					panic(err)
 				}
-				if err := f.Close(); err != nil {
+				if err := os.Remove(filename); err != nil {
+					time.Sleep(0)
 					panic(err)
 				}
 			}, nil

--- a/internal/builder/lock.go
+++ b/internal/builder/lock.go
@@ -28,7 +28,6 @@ func acquireLockFile() (release func(), err error) {
 					panic(err)
 				}
 				if err := os.Remove(filename); err != nil {
-					time.Sleep(0)
 					panic(err)
 				}
 			}, nil


### PR DESCRIPTION
The original lock management process would first try to `remove` the lock file and then `close` it. This led to the lock file not being removed properly and resulted in a **panic**. I reversed the order, so now it works normally.