### PR TITLE
Move Wait stream helper to streams package

### DIFF
--- a/benchmarks/message_passing/main.neva
+++ b/benchmarks/message_passing/main.neva
@@ -1,5 +1,7 @@
+import { streams }
+
 def Main(start any) (stop any) {
-    wait Wait
+    wait streams.Wait
     ---
     :start -> 1..1000 -> wait -> :stop
 }

--- a/e2e/for_loop_over_list_verbose/main/main.neva
+++ b/e2e/for_loop_over_list_verbose/main/main.neva
@@ -1,12 +1,13 @@
 import {
     fmt
     runtime
+    streams
 }
 
 const lst list<int> = [50, 30, 20, 100]
 
 def Main(start any) (stop any) {
-    ListToStream<int>, For<int>{fmt.Println}, Wait, runtime.Panic
+    ListToStream<int>, For<int>{fmt.Println}, streams.Wait, runtime.Panic
     ---
     :start -> $lst -> listToStream -> for
     for:res -> wait -> :stop

--- a/e2e/for_with_range_and_if/main/main.neva
+++ b/e2e/for_with_range_and_if/main/main.neva
@@ -1,9 +1,9 @@
-import { lists, fmt, runtime }
+import { lists, fmt, runtime, streams }
 
 const lst list<bool> = [true, false]
 
 def Main(start any) (stop any) {
-	ListToStream<bool>, For<bool>{PrintAsNum}, Wait, runtime.Panic
+        ListToStream<bool>, For<bool>{PrintAsNum}, streams.Wait, runtime.Panic
 	---
 	:start -> $lst -> listToStream -> for
 	for:res -> wait -> :stop

--- a/e2e/slow_iteration_with_for/main/main.neva
+++ b/e2e/slow_iteration_with_for/main/main.neva
@@ -2,12 +2,12 @@
 // https://github.com/nevalang/neva/issues/575
 // all elements of the array must be printed before program terminate
 
-import { time, fmt, runtime }
+import { time, fmt, runtime, streams }
 
 const lst list<int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 def Main(start any) (stop any) {
-    ListToStream<int>, For{Slow}, Wait, runtime.Panic
+    ListToStream<int>, For{Slow}, streams.Wait, runtime.Panic
     ---
     :start -> $lst -> listToStream -> for
     for:res -> wait -> :stop

--- a/examples/99_bottles/main.neva
+++ b/examples/99_bottles/main.neva
@@ -1,11 +1,12 @@
 import {
     fmt
     runtime
+    streams
 }
 
 def Main(start any) (stop any) {
 	print For<int>{Next2Lines}
-	wait Wait
+        wait streams.Wait
 	panic runtime.Panic
 	---
 	:start -> 99..-1 -> print

--- a/examples/filter_list/main.neva
+++ b/examples/filter_list/main.neva
@@ -1,6 +1,7 @@
 import {
     fmt
     runtime
+    streams
 }
 
 const numbers list<int> = [2, 4, 6, 8, 10]
@@ -9,7 +10,7 @@ def Main(start any) (stop any) {
     list_to_stream ListToStream<int>
     filter_even Filter<int>{predicate IsEven}
     for_print For<int>{fmt.Println<int>}
-    wait Wait
+    wait streams.Wait
     panic runtime.Panic
     ---
     :start -> $numbers -> list_to_stream -> filter_even -> for_print

--- a/examples/fizzbuzz/main.neva
+++ b/examples/fizzbuzz/main.neva
@@ -1,12 +1,13 @@
 import {
     fmt
     runtime
+    streams
 }
 
 def Main(start any) (stop any) {
     Map<int, any>{FizzBuzz}
     For{fmt.Println}
-    Wait
+    streams.Wait
     panic runtime.Panic
     ---
     :start -> 1..101 -> map -> for

--- a/examples/for_loop_over_list/main.neva
+++ b/examples/for_loop_over_list/main.neva
@@ -1,12 +1,13 @@
 import {
     fmt
     runtime
+    streams
 }
 
 const lst list<int> = [1, 2, 3]
 
 def Main(start any) (stop any) {
-    ListToStream<int>, For<int>{fmt.Println<int>}, Wait, runtime.Panic
+    ListToStream<int>, For<int>{fmt.Println<int>}, streams.Wait, runtime.Panic
     ---
     :start -> $lst -> listToStream -> for
     for:res -> wait -> :stop

--- a/examples/get_args/main.neva
+++ b/examples/get_args/main.neva
@@ -1,7 +1,7 @@
-import { os, fmt, runtime }
+import { os, fmt, runtime, streams }
 
 def Main(start any) (stop any) {
-	os.Args, ListToStream, For{fmt.Println}, Wait, runtime.Panic
+        os.Args, ListToStream, For{fmt.Println}, streams.Wait, runtime.Panic
 	---
 	:start -> args -> listToStream -> for
 	for:res -> wait -> :stop

--- a/examples/match/main.neva
+++ b/examples/match/main.neva
@@ -1,10 +1,11 @@
 import {
     fmt
     runtime
+    streams
 }
 
 def Main(start any) (stop any) {
-    For{Handler}, Wait, runtime.Panic
+    For{Handler}, streams.Wait, runtime.Panic
     ---
     :start -> 1..5 -> for
     for:res -> wait -> :stop

--- a/examples/select/main.neva
+++ b/examples/select/main.neva
@@ -1,11 +1,11 @@
 // we could use match instead, but we show Select here
 
-import { time, fmt, runtime }
+import { time, fmt, runtime, streams }
 
 def Main(start any) (stop any) {
     Map<int, string>{Handler}
     For<string>{fmt.Println}
-    Wait
+    streams.Wait
     runtime.Panic
     ---
     :start -> 1..5 -> map -> for

--- a/examples/stream_product/main.neva
+++ b/examples/stream_product/main.neva
@@ -5,7 +5,7 @@ type ProductResult streams.ProductResult<int, int>
 def Main(start any) (stop any) {
 	streams.Product<int, int>
 	For<ProductResult>{fmt.Println<ProductResult>}
-	Wait
+        streams.Wait
 	runtime.Panic
 	---
 	:start -> [

--- a/examples/stream_zip/main.neva
+++ b/examples/stream_zip/main.neva
@@ -4,7 +4,7 @@ const strings list<string> = ['a', 'b', 'c']
 
 def Main(start any) (stop any) {
 	ListToStream<string>, streams.Zip<int, string>
-	For{fmt.Println}, Wait, runtime.Panic
+        For{fmt.Println}, streams.Wait, runtime.Panic
 	---
         :start -> 0..10 -> zip:left
         $strings -> listToStream -> zip:right

--- a/examples/stream_zip_many/main.neva
+++ b/examples/stream_zip_many/main.neva
@@ -14,7 +14,7 @@ def Main(start any) (stop any) {
         l2s3 ListToStream<int>
         zip_many streams.ZipMany<int>
         for For<list<int>>{fmt.Println<list<int>>}
-        wait Wait
+        wait streams.Wait
         panic runtime.Panic
         ---
         :start -> [

--- a/std/builtin/streams.neva
+++ b/std/builtin/streams.neva
@@ -1,15 +1,3 @@
-// --- Basic operations ---
-
-// Wait blocks until last stream item arrive, then sends a signal.
-pub def Wait(data stream<any>) (sig any) {
-    del Del
-    ---
-    :data -> .last -> switch {
-        true -> :sig
-        _ -> del
-    }
-}
-
 // ArrPortToStream iterates over all array-inport's slots in order
 // and produces a stream of messages.
 #extern(array_port_to_stream)
@@ -107,7 +95,7 @@ pub def Accumulator<T>(init T, upd T, last bool) (cur T, res T)
 // This prevents concurrency issues.
 //
 // Like other iterators, it processes items one at a time without blocking the stream.
-// To wait for all items to be processed, use with `Wait`.
+// To wait for all items to be processed, use with `streams.Wait`.
 pub def For<T>(data stream<T>) (res stream<T>, err error) {
     // IDEA - if we use sync.Step, we don't have to mess with indexes
     

--- a/std/streams/streams.neva
+++ b/std/streams/streams.neva
@@ -1,3 +1,15 @@
+// --- Basic operations ---
+
+// Wait blocks until last stream item arrive, then sends a signal.
+pub def Wait(data stream<any>) (sig any) {
+    del Del
+    ---
+    :data -> .last -> switch {
+        true -> :sig
+        _ -> del
+    }
+}
+
 // === Zip ===
 
 pub type ZipResult<T, R> struct {


### PR DESCRIPTION
## Summary
- move the Wait stream helper into the streams package and update the builtin documentation reference
- update examples, benchmarks, and e2e fixtures to import streams and call streams.Wait explicitly

## Testing
- go test ./... *(fails: requires the `neva` executable in PATH for e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1f785b10832d8fcd57f59cc9b45e