### PR TITLE
Add `neva doc` command for stdlib search

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,7 @@ func NewApp(
 			newRunCmd(workdir, bldr, prsr, &desugarer, analyzer, irgen),
 			newBuildCmd(workdir, bldr, prsr, &desugarer, analyzer, irgen),
 			newOSArchCmd(),
+			newDocCmd(),
 		},
 	}
 }

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	cli "github.com/urfave/cli/v2"
+
+	"github.com/nevalang/neva/std"
+)
+
+func newDocCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "doc",
+		Usage:     "Search the standard library for symbols using regular expressions",
+		ArgsUsage: "[package/path] [.] <pattern>",
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:    "context",
+				Aliases: []string{"C"},
+				Value:   2,
+				Usage:   "number of context lines to display around each match",
+			},
+		},
+		Action: func(cliCtx *cli.Context) error {
+			pkgPath, pattern, err := parseDocArgs(cliCtx.Args())
+			if err != nil {
+				return err
+			}
+
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return fmt.Errorf("invalid pattern: %w", err)
+			}
+
+			matches, err := searchStdlib(pkgPath, re, cliCtx.Int("context"))
+			if err != nil {
+				return err
+			}
+
+			if len(matches) == 0 {
+				fmt.Println("No matches found")
+				return nil
+			}
+
+			sort.Slice(matches, func(i, j int) bool {
+				if matches[i].file == matches[j].file {
+					return matches[i].line < matches[j].line
+				}
+				return matches[i].file < matches[j].file
+			})
+
+			for _, m := range matches {
+				fmt.Printf("std/%s:%d\n", m.file, m.line)
+				for _, ctxLine := range m.context {
+					marker := " "
+					if ctxLine.line == m.line {
+						marker = ">"
+					}
+					fmt.Printf("%s %6d | %s\n", marker, ctxLine.line, ctxLine.text)
+				}
+				fmt.Println()
+			}
+
+			return nil
+		},
+	}
+}
+
+type docMatch struct {
+	file    string
+	line    int
+	context []docContextLine
+}
+
+type docContextLine struct {
+	line int
+	text string
+}
+
+func parseDocArgs(args cli.Args) (string, string, error) {
+	switch args.Len() {
+	case 0:
+		return "", "", errors.New("expected at least 1 argument")
+	case 1:
+		return "", args.Get(0), nil
+	case 2:
+		pkgPath := normalizePkgArg(args.Get(0))
+		if pkgPath == "" {
+			return "", args.Get(1), nil
+		}
+		return pkgPath, args.Get(1), nil
+	case 3:
+		if args.Get(1) != "." {
+			return "", "", errors.New("second argument must be '.' when three arguments are provided")
+		}
+		pkgPath := normalizePkgArg(args.Get(0))
+		return pkgPath, args.Get(2), nil
+	default:
+		return "", "", errors.New("expected at most 3 arguments")
+	}
+}
+
+func normalizePkgArg(arg string) string {
+	trimmed := strings.TrimSpace(arg)
+	if trimmed == "." {
+		return ""
+	}
+	trimmed = strings.Trim(trimmed, "/")
+	return strings.ReplaceAll(trimmed, "\\", "/")
+}
+
+func searchStdlib(pkgPath string, re *regexp.Regexp, context int) ([]docMatch, error) {
+	if context < 0 {
+		context = 0
+	}
+
+	var fsys fs.FS = std.FS
+	basePath := ""
+
+	if pkgPath != "" {
+		sub, err := fs.Sub(std.FS, pkgPath)
+		if err != nil {
+			return nil, fmt.Errorf("package %q not found in stdlib: %w", pkgPath, err)
+		}
+		fsys = sub
+		basePath = pkgPath
+	}
+
+	matches := make([]docMatch, 0)
+	err := fs.WalkDir(fsys, ".", func(entryPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(entryPath, ".neva") {
+			return nil
+		}
+
+		data, err := fs.ReadFile(fsys, entryPath)
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+		for i, line := range lines {
+			if !re.MatchString(line) {
+				continue
+			}
+
+			start := i - context
+			if start < 0 {
+				start = 0
+			}
+			end := i + context
+			if end >= len(lines) {
+				end = len(lines) - 1
+			}
+
+			contextLines := make([]docContextLine, 0, end-start+1)
+			for idx := start; idx <= end; idx++ {
+				contextLines = append(contextLines, docContextLine{
+					line: idx + 1,
+					text: lines[idx],
+				})
+			}
+
+			relativePath := entryPath
+			if basePath != "" {
+				relativePath = path.Join(basePath, entryPath)
+			}
+
+			matches = append(matches, docMatch{
+				file:    relativePath,
+				line:    i + 1,
+				context: contextLines,
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return matches, nil
+}

--- a/internal/cli/doc_test.go
+++ b/internal/cli/doc_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import "testing"
+
+type stubArgs []string
+
+func (a stubArgs) Get(n int) string {
+	if len(a) > n {
+		return a[n]
+	}
+	return ""
+}
+
+func (a stubArgs) First() string {
+	return a.Get(0)
+}
+
+func (a stubArgs) Tail() []string {
+	if len(a) >= 2 {
+		tail := make([]string, len(a)-1)
+		copy(tail, a[1:])
+		return tail
+	}
+	return []string{}
+}
+
+func (a stubArgs) Len() int {
+	return len(a)
+}
+
+func (a stubArgs) Present() bool {
+	return len(a) != 0
+}
+
+func (a stubArgs) Slice() []string {
+	out := make([]string, len(a))
+	copy(out, a)
+	return out
+}
+
+func TestParseDocArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantPkg   string
+		wantPat   string
+		wantError bool
+	}{
+		{
+			name:    "pattern only",
+			args:    []string{"Range"},
+			wantPkg: "",
+			wantPat: "Range",
+		},
+		{
+			name:    "package and pattern",
+			args:    []string{"builtin/core", "Range"},
+			wantPkg: "builtin/core",
+			wantPat: "Range",
+		},
+		{
+			name:    "package dot pattern",
+			args:    []string{"builtin/core", ".", "Range"},
+			wantPkg: "builtin/core",
+			wantPat: "Range",
+		},
+		{
+			name:      "too few arguments",
+			args:      []string{},
+			wantError: true,
+		},
+		{
+			name:      "too many arguments",
+			args:      []string{"a", "b", "c", "d"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg, pat, err := parseDocArgs(stubArgs(tt.args))
+			if (err != nil) != tt.wantError {
+				t.Fatalf("expected error=%v got %v", tt.wantError, err)
+			}
+			if err != nil {
+				return
+			}
+			if pkg != tt.wantPkg {
+				t.Fatalf("expected pkg %q got %q", tt.wantPkg, pkg)
+			}
+			if pat != tt.wantPat {
+				t.Fatalf("expected pattern %q got %q", tt.wantPat, pat)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a `doc` CLI command that searches the embedded stdlib with regex and optional package scoping
- allow configurable context lines in the output and format matches similarly to grep
- cover argument parsing for the new command with unit tests

## Testing
- go test ./internal/cli

------
https://chatgpt.com/codex/tasks/task_e_68fd2d4ccd60832db57e4a8abdfd8e8f