### PR TITLE
Ensure normal connections carry meta data

### DIFF
--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -1335,6 +1335,7 @@ func (s *treeShapeListener) parseNormConn(
 		Normal: &src.NormalConnection{
 			Senders:   parsedSenderSide,
 			Receivers: parsedReceiverSide,
+			Meta:      meta,
 		},
 		Meta: meta,
 	}, nil


### PR DESCRIPTION
## Summary
- populate the NormalConnection metadata when parsing so analyzer errors can report the correct source location

## Testing
- not run (go test ./... hung locally and had to be aborted)


------
https://chatgpt.com/codex/tasks/task_e_68fd2e5a75e4832da2aa7f8e1e304833