### PR TITLE
Chain constant senders in examples

### DIFF
--- a/e2e/array_inport_holes/main/main.neva
+++ b/e2e/array_inport_holes/main/main.neva
@@ -1,10 +1,12 @@
 import { fmt }
 
 def Main(start any) (stop any) {
-	fmt.Printf
-	---
-	:start -> '$1 $2 $3' -> printf:tpl
-	1 -> printf:args[0]
-	3 -> printf:args[2]
-	[printf:sig, printf:err] -> :stop
+        fmt.Printf
+        ---
+        :start -> [
+            '$1 $2 $3' -> printf:tpl,
+            1 -> printf:args[0],
+            3 -> printf:args[2]
+        ]
+        [printf:sig, printf:err] -> :stop
 }

--- a/e2e/compiler_error_unused_outport/main/main.neva
+++ b/e2e/compiler_error_unused_outport/main/main.neva
@@ -9,7 +9,7 @@ def Main(start any) (stop any) {
     ---
     :start -> 'Hi, Neva!' -> sub1:data
     sub1:stop-> :stop
-    '1' -> sub2
+    :start -> '1' -> sub2
 }
 
 // Here we are panicking inside the sub-component instead of propagating the error.

--- a/e2e/errors_must/main/main.neva
+++ b/e2e/errors_must/main/main.neva
@@ -20,7 +20,9 @@ def Main(start any) (stop any) {
 def Handler(data string) (res any, err error) {
     write_all io.WriteAll?
     ---
-    :data -> write_all:filename
-    'Hello, io.WriteAll!' -> write_all:data
+    :data -> [
+        write_all:filename,
+        'Hello, io.WriteAll!' -> write_all:data
+    ]
     write_all:res -> :res
 }

--- a/e2e/hello_world_with_const_sender/main/main.neva
+++ b/e2e/hello_world_with_const_sender/main/main.neva
@@ -6,13 +6,15 @@ import {
 const greeting string = 'Hello, World!'
 
 def Main(start any) (stop any) {
-	println fmt.Println<string>
-	lock Lock<string>
-	panic runtime.Panic
-	---
-	:start -> lock:sig
-	$greeting -> lock:data
-	lock:data -> println:data
-	println:res -> :stop
-	println:err -> panic
+        println fmt.Println<string>
+        lock Lock<string>
+        panic runtime.Panic
+        ---
+        :start -> [
+            lock:sig,
+            $greeting -> lock:data
+        ]
+        lock:data -> println:data
+        println:res -> :stop
+        println:err -> panic
 }

--- a/e2e/multiply_numbers/main/main.neva
+++ b/e2e/multiply_numbers/main/main.neva
@@ -6,14 +6,16 @@ import {
 const l list<int> = [1, 2, 3]
 
 def Main(start any) (stop any) {
-	fmt.Println<int>
-	Reduce<int, int>{Mul}
-	ListToStream<int>
-	panic runtime.Panic
-	---
-	:start -> $l -> listToStream -> reduce:data
-	1 -> reduce:init
-	reduce -> println:data
-	println:res -> :stop
-	println:err -> panic
+        fmt.Println<int>
+        Reduce<int, int>{Mul}
+        ListToStream<int>
+        panic runtime.Panic
+        ---
+        :start -> [
+            $l -> listToStream -> reduce:data,
+            1 -> reduce:init
+        ]
+        reduce -> println:data
+        println:res -> :stop
+        println:err -> panic
 }

--- a/e2e/order_dependend_with_arr_inport/main/main.neva
+++ b/e2e/order_dependend_with_arr_inport/main/main.neva
@@ -7,13 +7,15 @@ const l list<int> = [1, 2, 3]
 
 def Main(start any) (stop any) {
 	fmt.Println<int>
-	Reduce<int, int>{Sub}
-	ListToStream<int>
-	panic runtime.Panic
-	---
-	:start -> $l -> listToStream -> reduce:data
-	0 -> reduce:init
-	reduce -> println:data
-	println:res -> :stop
-	println:err -> panic
+        Reduce<int, int>{Sub}
+        ListToStream<int>
+        panic runtime.Panic
+        ---
+        :start -> [
+            $l -> listToStream -> reduce:data,
+            0 -> reduce:init
+        ]
+        reduce -> println:data
+        println:res -> :stop
+        println:err -> panic
 }

--- a/e2e/slow_iteration_with_for/main/main.neva
+++ b/e2e/slow_iteration_with_for/main/main.neva
@@ -18,8 +18,10 @@ def Slow(data int) (res any, err error) {
     time.Delay<int>
     fmt.Println<int>?
     ---
-    :data -> delay:data
-    $time.second -> delay:dur
+    :data -> [
+        delay:data,
+        $time.second -> delay:dur
+    ]
     delay -> println:data
     println:res -> :res
 }

--- a/e2e/slow_iteration_with_map/main/main.neva
+++ b/e2e/slow_iteration_with_map/main/main.neva
@@ -22,7 +22,9 @@ def Slow(data int) (res int) {
     delay time.Delay<int>
     dec Dec
     ---
-    :data -> delay:data
-    $time.second -> delay:dur
+    :data -> [
+        delay:data,
+        $time.second -> delay:dur
+    ]
     delay -> dec -> :res
 }

--- a/examples/delayed_echo/main.neva
+++ b/examples/delayed_echo/main.neva
@@ -16,28 +16,30 @@ def Main(start any) (stop any) {
 	wg sync.WaitGroup
 	panic runtime.Panic
 	---
-	:start -> [
-		'Hello' -> println,
-		1 -> w1,
+        :start -> [
+                'Hello' -> println,
+                1 -> w1,
 		2 -> w2,
 		3 -> w3,
-		4 -> w4,
-		5 -> w5,
-		'World' -> w6
-	]
-	6 -> wg:count
-	[w1:sig, w2:sig, w3:sig, w4:sig, w5:sig, w6:sig, println:res] -> wg:sig
-	wg -> :stop
+                4 -> w4,
+                5 -> w5,
+                'World' -> w6,
+                6 -> wg:count
+        ]
+        [w1:sig, w2:sig, w3:sig, w4:sig, w5:sig, w6:sig, println:res] -> wg:sig
+        wg -> :stop
 	[w1:err, w2:err, w3:err, w4:err, w5:err, w6:err, println:err] -> panic
 }
 
 def Worker(data any) (sig any, err error) {
-	delay time.Delay
-	println fmt.Println?
-	---
-	:data -> delay:data
-	$time.second -> delay:dur
-	delay -> println -> :sig
+        delay time.Delay
+        println fmt.Println?
+        ---
+        :data -> [
+                delay:data,
+                $time.second -> delay:dur
+        ]
+        delay -> println -> :sig
 }
 
 // TODO add unit test

--- a/examples/dict/main.neva
+++ b/examples/dict/main.neva
@@ -11,8 +11,10 @@ const d dict<string> = {
 def Main(start any) (stop any) {
     Get, fmt.Println, runtime.Panic
     ---
-    :start -> 'name' -> get:key
-    $d -> get:dict
+    :start -> [
+        'name' -> get:key,
+        $d -> get:dict
+    ]
     [get:res, get:err] -> println:data
     println:res -> :stop
     println:err -> panic

--- a/examples/reduce_list/main.neva
+++ b/examples/reduce_list/main.neva
@@ -11,8 +11,10 @@ def Main(start any) (stop any) {
     println fmt.Println
     panic runtime.Panic
     ---
-    :start -> $lst -> l2s -> reduce:data
-    0 -> reduce:init
+    :start -> [
+        $lst -> l2s -> reduce:data,
+        0 -> reduce:init
+    ]
     reduce -> println:data
     println:res -> :stop
     println:err -> panic

--- a/examples/wait_group/main.neva
+++ b/examples/wait_group/main.neva
@@ -4,16 +4,16 @@ def Main(start any) (stop any) {
 	p1 fmt.Println
 	p2 fmt.Println
 	p3 fmt.Println
-	wg sync.WaitGroup
-	panic runtime.Panic
-	---
-	:start -> [
-		'Hello' -> p1,
-		'Neva' -> p2,
-		'World!' -> p3
-	]
-	[p1:res, p2:res, p3:res] -> wg:sig
-	3 -> wg:count
-	wg -> :stop
-	[p1:err, p2:err, p3:err] -> panic
+    wg sync.WaitGroup
+    panic runtime.Panic
+    ---
+    :start -> [
+            'Hello' -> p1,
+            'Neva' -> p2,
+            'World!' -> p3,
+            3 -> wg:count
+    ]
+    [p1:res, p2:res, p3:res] -> wg:sig
+    wg -> :stop
+    [p1:err, p2:err, p3:err] -> panic
 }


### PR DESCRIPTION
## Summary
- chain standalone constant and literal senders off start/data signals in examples and e2e fixtures
- ensure wait group counters and delay durations are triggered through the same connections as their consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e89e62324832da1b3d65bd25b74ce)