### PR TITLE
Fix chained connection meta fallback for error locations

### DIFF
--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -1478,6 +1478,13 @@ func (s *treeShapeListener) parseChainedConnExpr(
 		return src.ConnectionReceiver{}, err
 	}
 
+	if parsedConn.Meta.Start.Line == 0 && parsedConn.Meta.Start.Column == 0 {
+		parsedConn.Meta = connMeta
+		if parsedConn.Normal != nil {
+			parsedConn.Normal.Meta = connMeta
+		}
+	}
+
 	return src.ConnectionReceiver{
 		ChainedConnection: &parsedConn,
 		Meta:              connMeta,

--- a/internal/compiler/parser/parser_test.go
+++ b/internal/compiler/parser/parser_test.go
@@ -162,6 +162,9 @@ func TestParser_ParseFile_ChainedConnections(t *testing.T) {
 	chainReceiver := chain.Receivers[0].PortAddr
 	require.Equal(t, "out", chainReceiver.Node)
 	require.Equal(t, "bar", chainReceiver.Port)
+
+	require.Greater(t, chain.Meta.Start.Line, 0)
+	require.Greater(t, chain.Meta.Stop.Line, 0)
 }
 
 func TestParser_ParseFile_ChainedConnectionsWithConstants(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Chained connections parsed via `parseChainedConnExpr` could have empty positional metadata, causing compiler errors to report `:0:0` locations. 
- The change ensures error locations for chained connections reflect the receiver context when the parsed connection lacks position info. 
- This addresses incorrect line/column reporting observed when a chained connection AST node is constructed without start/stop positions. 

### Description
- Add a fallback in `parseChainedConnExpr` to copy `connMeta` into `parsedConn.Meta` and `parsedConn.Normal.Meta` when the parsed connection has zero `Start.Line` and `Start.Column`. 
- Ensure the chained connection receiver keeps the original receiver `Meta` context when the inner parsed connection has no position data. 
- Add assertions to `internal/compiler/parser/parser_test.go` to verify `chain.Meta.Start.Line` and `chain.Meta.Stop.Line` are populated. 

### Testing
- Ran `go test ./...`; package-level parser tests (including `internal/compiler/parser`) passed but the full test run failed due to an unrelated example test `examples/http_get` reporting "Domain forbidden". 
- Ran `golangci-lint run ./...` which failed due to the linter being built with Go 1.24 while the project targets Go 1.25. 
- Ran `make build` which was interrupted (long-running cross-build target) and did not complete. 
- The new parser test assertions were added and exercised by the parser unit tests that were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d97fa8ec832da111124728b7029a)