### PR TITLE
Improve unused inport error messages

### DIFF
--- a/internal/compiler/analyzer/network.go
+++ b/internal/compiler/analyzer/network.go
@@ -6,6 +6,8 @@ package analyzer
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/nevalang/neva/internal/compiler"
 	src "github.com/nevalang/neva/internal/compiler/ast"
@@ -260,17 +262,27 @@ func (a Analyzer) analyzeNetPortsUsage(
 	// 1. every self inport must be used
 	inportsUsage, ok := nodesUsage["in"]
 	if !ok {
+		allInports := make([]string, 0, len(iface.IO.In))
+		for inportName := range iface.IO.In {
+			allInports = append(allInports, inportName)
+		}
+
 		return &compiler.Error{
-			Message: "Unused inports",
+			Message: unusedPortsMessage("inport", allInports),
 			Meta:    &iface.Meta,
 		}
 	}
 
+	unusedInports := make([]string, 0, len(iface.IO.In))
 	for inportName := range iface.IO.In {
 		if _, ok := inportsUsage.Out[inportName]; !ok { // note that self inports are outports for the network
-			return &compiler.Error{
-				Message: fmt.Sprintf("Unused inport: %v", inportName),
-			}
+			unusedInports = append(unusedInports, inportName)
+		}
+	}
+	if len(unusedInports) > 0 {
+		return &compiler.Error{
+			Message: unusedPortsMessage("inport", unusedInports),
+			Meta:    &iface.Meta,
 		}
 	}
 
@@ -423,6 +435,14 @@ func (a Analyzer) analyzeNetPortsUsage(
 	}
 
 	return nil
+}
+
+func unusedPortsMessage(portType string, ports []string) string {
+	sort.Strings(ports)
+	if len(ports) == 1 {
+		return fmt.Sprintf("Unused %s: %s", portType, ports[0])
+	}
+	return fmt.Sprintf("Unused %ss: %s", portType, strings.Join(ports, ", "))
 }
 
 // getResolvedPortType returns resolved port-addr, type expr and isArray bool.


### PR DESCRIPTION
### Motivation

- Make diagnostics clearer when a component has unused inports by listing specific port names and using correct singular/plural wording.
- Surface unused inports even when no inports are connected to the network so the error points to the component interface instead of a generic message.

### Description

- Updated `internal/compiler/analyzer/network.go` to collect and report unused inport names instead of emitting a generic "Unused inports" message.
- Added `unusedPortsMessage` helper to format singular/plural messages and join multiple port names, and imported `sort` and `strings` to support deterministic output.
- When no inports are connected the analyzer now reports all declared inport names for the component.

### Testing

- Ran `make build` (interrupted/hung before completion).
- Ran `golangci-lint run ./...` which failed because the `golangci-lint` binary was built with Go 1.24 while the project targets Go 1.25.
- Attempted `go test ./...` but the run was interrupted/hung and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d9ad0e54832d80ca7363a7168249)