### PR TITLE
Emit debug validation only in generated runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ The standard library provides components for all programs. Some are implemented 
 
 - **IR**: `neva run --target ir <pkg>`
 - **Trace**: `neva run --emit-trace <pkg>`
+- **Runtime validation**: `neva run --debug-runtime-validation <pkg>` or `neva build --debug-runtime-validation <pkg>` (compiler-only check that prints unconnected senders/receivers to validate runtime wiring; intended for language developers inspecting compiler output)
 
 **Debug the CLI/Compiler**:
 

--- a/e2e/cli/debug_runtime_validation/e2e_test.go
+++ b/e2e/cli/debug_runtime_validation/e2e_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/nevalang/neva/pkg/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugRuntimeValidation(t *testing.T) {
+	_ = os.RemoveAll("gen")
+	_ = os.RemoveAll("src")
+	_ = os.Remove("neva.yml")
+	_ = os.Remove("neva.yaml")
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll("gen")
+		_ = os.RemoveAll("src")
+		_ = os.Remove("neva.yml")
+		_ = os.Remove("neva.yaml")
+	})
+
+	e2e.Run(t, []string{"new", "."})
+
+	// Ensure the debug validation flag doesn't interfere with running the program.
+	out, _ := e2e.Run(t, []string{"run", "--debug-runtime-validation", "src"})
+	require.Equal(t, "Hello, World!\n", out)
+
+	// Build Go output with debug validation enabled so runtime sources are emitted.
+	e2e.Run(t, []string{"build", "--target=go", "--debug-runtime-validation", "--output=gen", "src"})
+
+	// Verify the generated runtime includes the debug validation helper.
+	debugPath := filepath.Join("gen", "runtime", "debug_validation.go")
+	debugBytes, err := os.ReadFile(debugPath)
+	require.NoError(t, err)
+	require.Contains(t, string(debugBytes), "func DebugValidation")
+
+	// Build the generated Go module to ensure the code compiles.
+	buildCmd := exec.Command("go", "build", "-o", "app", ".")
+	buildCmd.Dir = "gen"
+	buildOut, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, string(buildOut))
+
+	// Execute the built binary and assert the hello world output.
+	binaryPath := filepath.Join("gen", "app")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
+
+	runCmd := exec.Command(binaryPath)
+	runOut, err := runCmd.CombinedOutput()
+	require.NoError(t, err, string(runOut))
+	require.Equal(t, "Hello, World!\n", string(runOut))
+}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -41,6 +41,10 @@ func newBuildCmd(
 				Name:  "emit-trace",
 				Usage: "Emit trace file",
 			},
+			&cli.BoolFlag{
+				Name:  "debug-runtime-validation",
+				Usage: "Enable compiler runtime port validation (language developers only)",
+			},
 			&cli.StringFlag{
 				Name:  "target",
 				Usage: "Target platform (go, wasm, native, ir)",
@@ -164,7 +168,10 @@ func newBuildCmd(
 				externalRuntimePath = filepath.Join(workdir, externalRuntimePath)
 			}
 
-			golangBackend := golang.NewBackend(externalRuntimePath)
+			golangBackend := golang.NewBackend(
+				externalRuntimePath,
+				cliCtx.Bool("debug-runtime-validation"),
+			)
 
 			switch target {
 			case "go":

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -98,7 +98,7 @@ func newInstallCmd(
 				&desugarer,
 				analyzer,
 				irgen,
-				golang.NewBackend(""),
+				golang.NewBackend("", false),
 			)
 
 			if _, err := compilerToGo.Compile(cliCtx.Context, compiler.CompilerInput{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -37,6 +37,10 @@ func newRunCmd(
 				Usage: "Write real-time trace to a file",
 			},
 			&cli.BoolFlag{
+				Name:  "debug-runtime-validation",
+				Usage: "Enable compiler runtime port validation (language developers only)",
+			},
+			&cli.BoolFlag{
 				Name:  "emit-ir",
 				Usage: "Emit intermediate representation before running",
 			},
@@ -128,7 +132,7 @@ func newRunCmd(
 					analyzer,
 					irgen,
 					native.NewBackend(
-						golang.NewBackend(""),
+						golang.NewBackend("", cliCtx.Bool("debug-runtime-validation")),
 					),
 				)
 

--- a/internal/compiler/backend/golang/backend.go
+++ b/internal/compiler/backend/golang/backend.go
@@ -22,6 +22,7 @@ import (
 
 type Backend struct {
 	externalRuntimePath string
+	debugValidation     bool
 }
 
 var (
@@ -61,6 +62,7 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 		FuncCalls:       funcCalls,
 		Trace:           trace,
 		TraceComment:    prog.Comment,
+		DebugValidation: b.debugValidation,
 	}
 
 	var buf bytes.Buffer
@@ -75,6 +77,9 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 
 	if err := b.insertRuntimeFiles(files, nil); err != nil {
 		return err
+	}
+	if b.debugValidation {
+		files["runtime/debug_validation.go"] = []byte(debugValidationGoTemplate)
 	}
 
 	return pkgos.SaveFilesToDir(dst, files)
@@ -536,8 +541,9 @@ func (b Backend) chanVarNameFromPortAddr(addr ir.PortAddr) string {
 	return handleSpecialChars(s)
 }
 
-func NewBackend(runtimeImportPath string) Backend {
+func NewBackend(runtimeImportPath string, debugValidation bool) Backend {
 	return Backend{
 		externalRuntimePath: runtimeImportPath,
+		debugValidation:     debugValidation,
 	}
 }

--- a/internal/runtime/program.go
+++ b/internal/runtime/program.go
@@ -237,7 +237,7 @@ func (a ArrayInport) _select(ctx context.Context) ([]SelectedMsg, bool) {
 		if len(buf) > 0 && i >= len(a.chans) {
 			break
 		}
-		
+
 		for slotIdx, ch := range a.chans {
 			select {
 			default:


### PR DESCRIPTION
### Motivation

- Keep the repository `internal/runtime` package free of a rarely-used compiler-only helper so that emitted programs don't include the function in every source tree. 
- Provide a way for language developers to enable a compiler-only runtime wiring validator that prints unconnected senders/receivers for inspecting generated Go code. 
- Make the feature opt-in from the CLI via `--debug-runtime-validation` so normal builds are unaffected. 
- Avoid changing the runtime API surface while still emitting real, compilable validation code into generated modules.

### Description

- Removed the shipped `internal/runtime/debug_validation.go` and added a `debugValidationGoTemplate` in `internal/compiler/backend/golang/tpl.go` so the helper is generated only into the produced module when needed. 
- Updated `internal/compiler/backend/golang/backend.go` to accept a `debugValidation` flag in `NewBackend` and to emit `runtime/debug_validation.go` into `files` when the flag is enabled. 
- Threaded the new flag through CLI construction by adding `--debug-runtime-validation` to `internal/cli/run.go` and `internal/cli/build.go` and by passing the flag into `golang.NewBackend`, while keeping the runtime package source untouched. 
- Added an e2e test `e2e/cli/debug_runtime_validation/e2e_test.go` and documented the flag in `AGENTS.md`, and updated generated `main.go` template to call `runtime.DebugValidation(rprog)` only when enabled.

### Testing

- `make build` succeeded. 
- The new e2e test `e2e/cli/debug_runtime_validation` ran and passed under `go test`. 
- `golangci-lint run ./...` failed due to the linter being built with Go 1.24 while the repo targets Go 1.25. 
- `go test ./...` did not complete successfully due to a timeout in `e2e/order_dependend_with_arr_inport` (test timed out after 10m).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d92f6b78832dba8e0f5d9b2d4df6)