### PR TITLE
refactor: move ast and core packages to pkg

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ Follow these instructions.
 - **Common patterns**: Keep `implementations` codelenses interface-only; component lenses stay on `references` and can include references to interfaces they structurally implement.
 - **Architecture insights**: VS Code TextMate grammar (`vscode-neva/syntaxes`) coexists with LSP semantic tokens; no mandatory grammar removal is needed for MVP rollout.
 - **Common patterns**: LSP tests are easiest to scale with small in-memory build fixtures plus focused handler-level assertions (`TextDocumentCodeLens`, `CodeLensResolve`) instead of end-to-end editor wiring.
+
+### Session Notes (2026-02-14, AST/Core extraction prep)
+
+- **Architecture insights**: `ast` and `core` are now externalized under `pkg/` (`pkg/ast`, `pkg/core`) so other Go modules (like a split LSP repo) can import them without `internal/` restrictions.
+- **Common patterns**: For large package moves, do physical file moves first, then repo-wide import rewrites, then trim formatting-only churn to keep PR review focused.
+- **Gotchas**: Broad `gofmt` runs can introduce noisy doc-comment/newline changes in unrelated files; revert those hunks unless they are intentional.
 ## 3. ⚡ Core Concepts
 
 - **Dataflow**: Programs are graphs. Nodes process data; edges transport it.

--- a/cmd/lsp/indexer/indexer.go
+++ b/cmd/lsp/indexer/indexer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nevalang/neva/internal/compiler"
 	"github.com/nevalang/neva/internal/compiler/analyzer"
 	"github.com/nevalang/neva/internal/compiler/parser"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 type Indexer struct {

--- a/cmd/lsp/server/codelens.go
+++ b/cmd/lsp/server/codelens.go
@@ -11,8 +11,8 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type codeLensData struct {

--- a/cmd/lsp/server/get_file_view.go
+++ b/cmd/lsp/server/get_file_view.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 type GetFileViewRequest struct {

--- a/cmd/lsp/server/language_features.go
+++ b/cmd/lsp/server/language_features.go
@@ -12,8 +12,8 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // TextDocumentCompletion provides context-aware completions for ports, packages, and keywords.

--- a/cmd/lsp/server/lsp_features_test.go
+++ b/cmd/lsp/server/lsp_features_test.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"testing"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/cmd/lsp/server/semantic_tokens.go
+++ b/cmd/lsp/server/semantic_tokens.go
@@ -11,8 +11,8 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // semanticTokenTypes returns the token names declared in the semantic token legend.

--- a/cmd/lsp/server/server.go
+++ b/cmd/lsp/server/server.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/nevalang/neva/cmd/lsp/indexer"
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 //nolint:govet // fieldalignment: preserve layout for readability.

--- a/cmd/lsp/server/symbols.go
+++ b/cmd/lsp/server/symbols.go
@@ -13,9 +13,9 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type fileContext struct {

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/pkg"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type Builder struct {

--- a/internal/builder/get.go
+++ b/internal/builder/get.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (b Builder) Get(wd, path, version string) (string, error) {

--- a/internal/builder/git.go
+++ b/internal/builder/git.go
@@ -7,7 +7,7 @@ import (
 
 	gitlib "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 	nevaGit "github.com/nevalang/neva/pkg/git"
 )
 

--- a/internal/builder/manifest.go
+++ b/internal/builder/manifest.go
@@ -9,7 +9,7 @@ import (
 
 	yaml "gopkg.in/yaml.v3"
 
-	ast "github.com/nevalang/neva/internal/compiler/ast"
+	ast "github.com/nevalang/neva/pkg/ast"
 )
 
 func (p Builder) getNearestManifest(wd string) (ast.ModuleManifest, string, error) {

--- a/internal/builder/q.go
+++ b/internal/builder/q.go
@@ -1,6 +1,6 @@
 package builder
 
-import "github.com/nevalang/neva/internal/compiler/ast/core"
+import "github.com/nevalang/neva/pkg/core"
 
 type queue []core.ModuleRef
 

--- a/internal/compiler/analyzer/analyzer.go
+++ b/internal/compiler/analyzer/analyzer.go
@@ -9,9 +9,9 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type Analyzer struct {

--- a/internal/compiler/analyzer/component.go
+++ b/internal/compiler/analyzer/component.go
@@ -2,7 +2,7 @@ package analyzer
 
 import (
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 func (a Analyzer) analyzeComponent(

--- a/internal/compiler/analyzer/const.go
+++ b/internal/compiler/analyzer/const.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 var (

--- a/internal/compiler/analyzer/interface.go
+++ b/internal/compiler/analyzer/interface.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 var (

--- a/internal/compiler/analyzer/main_component.go
+++ b/internal/compiler/analyzer/main_component.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 func (a Analyzer) analyzeMainComponent(cmp src.Component, scope src.Scope) *compiler.Error {

--- a/internal/compiler/analyzer/main_pkg.go
+++ b/internal/compiler/analyzer/main_pkg.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (a Analyzer) mainSpecificPkgValidation(mainPkgName string, mod src.Module, scope src.Scope) *compiler.Error {

--- a/internal/compiler/analyzer/network.go
+++ b/internal/compiler/analyzer/network.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var ErrComplexLiteralSender = errors.New("literal network sender must have primitive type")

--- a/internal/compiler/analyzer/network_test.go
+++ b/internal/compiler/analyzer/network_test.go
@@ -3,8 +3,8 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/compiler/analyzer/nodes.go
+++ b/internal/compiler/analyzer/nodes.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type foundInterface struct {
@@ -1030,7 +1030,6 @@ type receiverSenderPair struct {
 //
 //	:start -> U::A -> switch:case[0]
 //	  => pairs: (switch:case[0] <- U::A)
-//
 func (a Analyzer) collectReceiverSenderPairs(
 	receivers []src.ConnectionReceiver,
 	senders []src.ConnectionSender,

--- a/internal/compiler/analyzer/receivers.go
+++ b/internal/compiler/analyzer/receivers.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (a Analyzer) analyzeReceivers(

--- a/internal/compiler/analyzer/semver.go
+++ b/internal/compiler/analyzer/semver.go
@@ -6,9 +6,9 @@ import (
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/pkg"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // semverCheck ensures that module is compatible with existing compiler

--- a/internal/compiler/analyzer/senders.go
+++ b/internal/compiler/analyzer/senders.go
@@ -2,9 +2,9 @@ package analyzer
 
 import (
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (a Analyzer) analyzeSenders(

--- a/internal/compiler/analyzer/switch_logic.go
+++ b/internal/compiler/analyzer/switch_logic.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // getSwitchCaseOutportType resolves the specialized type for a Switch case output.

--- a/internal/compiler/analyzer/type.go
+++ b/internal/compiler/analyzer/type.go
@@ -2,8 +2,8 @@ package analyzer
 
 import (
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 type analyzeTypeDefParams struct {

--- a/internal/compiler/analyzer/union_logic.go
+++ b/internal/compiler/analyzer/union_logic.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 type unionActiveTagInfo struct {

--- a/internal/compiler/analyzer/utils.go
+++ b/internal/compiler/analyzer/utils.go
@@ -3,7 +3,7 @@ package analyzer
 import (
 	"fmt"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 type netNodesUsage map[string]netNodeUsage

--- a/internal/compiler/backend/golang/backend.go
+++ b/internal/compiler/backend/golang/backend.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/nevalang/neva/internal"
 	"github.com/nevalang/neva/internal/compiler"
-	"github.com/nevalang/neva/internal/compiler/ast"
 	"github.com/nevalang/neva/internal/compiler/ir"
 	"github.com/nevalang/neva/pkg"
+	"github.com/nevalang/neva/pkg/ast"
 	"github.com/nevalang/neva/pkg/golang"
 	pkgos "github.com/nevalang/neva/pkg/os"
 )

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/internal/compiler/ir"
+	"github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type Compiler struct {

--- a/internal/compiler/contract.go
+++ b/internal/compiler/contract.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/nevalang/neva/internal/compiler/ir"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 const (

--- a/internal/compiler/desugarer/component.go
+++ b/internal/compiler/desugarer/component.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"slices"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 //nolint:govet // fieldalignment: keep semantic grouping.

--- a/internal/compiler/desugarer/const.go
+++ b/internal/compiler/desugarer/const.go
@@ -2,7 +2,7 @@ package desugarer
 
 import (
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 // handleConst handles case when constant has integer value and type is float.

--- a/internal/compiler/desugarer/del.go
+++ b/internal/compiler/desugarer/del.go
@@ -1,8 +1,8 @@
 package desugarer
 
 import (
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type unusedOutportsResult struct {

--- a/internal/compiler/desugarer/desugarer.go
+++ b/internal/compiler/desugarer/desugarer.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"maps"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/pkg"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // Desugarer is NOT thread safe and must be used in single thread

--- a/internal/compiler/desugarer/desugarer_test.go
+++ b/internal/compiler/desugarer/desugarer_test.go
@@ -3,9 +3,9 @@ package desugarer
 import (
 	"testing"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/pkg"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/compiler/desugarer/mocks_test.go
+++ b/internal/compiler/desugarer/mocks_test.go
@@ -8,8 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	sourcecode "github.com/nevalang/neva/internal/compiler/ast"
-	core "github.com/nevalang/neva/internal/compiler/ast/core"
+	sourcecode "github.com/nevalang/neva/pkg/ast"
+	core "github.com/nevalang/neva/pkg/core"
 )
 
 // MockScope is a mock of Scope interface.

--- a/internal/compiler/desugarer/network.go
+++ b/internal/compiler/desugarer/network.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 const maxUint8 = int(^uint8(0))

--- a/internal/compiler/desugarer/network_test.go
+++ b/internal/compiler/desugarer/network_test.go
@@ -5,9 +5,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/compiler/desugarer/node.go
+++ b/internal/compiler/desugarer/node.go
@@ -5,8 +5,8 @@ import (
 	"maps"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (Desugarer) handleNode(

--- a/internal/compiler/desugarer/node_test.go
+++ b/internal/compiler/desugarer/node_test.go
@@ -3,8 +3,8 @@ package desugarer
 import (
 	"testing"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/compiler/desugarer/struct_selectors.go
+++ b/internal/compiler/desugarer/struct_selectors.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type desugarStructSelectorsResult struct {

--- a/internal/compiler/error.go
+++ b/internal/compiler/error.go
@@ -3,7 +3,7 @@ package compiler
 import (
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 //nolint:govet // fieldalignment: keep semantic grouping.

--- a/internal/compiler/irgen/func.go
+++ b/internal/compiler/irgen/func.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	"github.com/nevalang/neva/internal/compiler/ir"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 func (Generator) getFuncRef(versions []src.Component, node src.Node) (string, src.Component) {

--- a/internal/compiler/irgen/irgen.go
+++ b/internal/compiler/irgen/irgen.go
@@ -3,10 +3,10 @@ package irgen
 import (
 	"fmt"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	"github.com/nevalang/neva/internal/compiler/ir"
 	"github.com/nevalang/neva/pkg"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type Generator struct{}
@@ -202,10 +202,10 @@ func (g Generator) processNode(
 					continue
 				}
 
-			// if sub-node has DI arg, we check if it's interface
-			// we must relocate scope to the component's location because existing.EntityRef
-			// is a local reference (Pkg="") that needs to be resolved in the component's package
-			kind, err := scope.Relocate(location).GetEntityKind(existing.EntityRef)
+				// if sub-node has DI arg, we check if it's interface
+				// we must relocate scope to the component's location because existing.EntityRef
+				// is a local reference (Pkg="") that needs to be resolved in the component's package
+				kind, err := scope.Relocate(location).GetEntityKind(existing.EntityRef)
 				if err != nil {
 					panic(err)
 				}

--- a/internal/compiler/irgen/message.go
+++ b/internal/compiler/irgen/message.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/nevalang/neva/internal/compiler/ir"
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 func getIRMsgBySrcRef(

--- a/internal/compiler/irgen/network.go
+++ b/internal/compiler/irgen/network.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
 	"github.com/nevalang/neva/internal/compiler/ir"
+	src "github.com/nevalang/neva/pkg/ast"
 )
 
 // processNetwork inserts connections to result and returns metadata about the network.

--- a/internal/compiler/parser/err_handler.go
+++ b/internal/compiler/parser/err_handler.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/nevalang/neva/internal/compiler"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type CustomErrorListener struct {

--- a/internal/compiler/parser/listener.go
+++ b/internal/compiler/parser/listener.go
@@ -2,8 +2,8 @@ package parser
 
 import (
 	generated "github.com/nevalang/neva/internal/compiler/parser/generated"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 //nolint:govet // fieldalignment: listener fields grouped.

--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	generated "github.com/nevalang/neva/internal/compiler/parser/generated"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (s *treeShapeListener) parseImport(actx generated.IImportDefContext) (src.Import, string) {

--- a/internal/compiler/parser/manifest.go
+++ b/internal/compiler/parser/manifest.go
@@ -5,8 +5,8 @@ import (
 
 	yaml "gopkg.in/yaml.v3"
 
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func (p Parser) ParseManifest(raw []byte) (src.ModuleManifest, error) {

--- a/internal/compiler/parser/parser.go
+++ b/internal/compiler/parser/parser.go
@@ -9,9 +9,9 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	generated "github.com/nevalang/neva/internal/compiler/parser/generated"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 type Parser struct{}

--- a/internal/compiler/parser/parser_test.go
+++ b/internal/compiler/parser/parser_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/nevalang/neva/internal/compiler"
-	src "github.com/nevalang/neva/internal/compiler/ast"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/compiler/typesystem/helper.go
+++ b/internal/compiler/typesystem/helper.go
@@ -1,6 +1,6 @@
 package typesystem
 
-import "github.com/nevalang/neva/internal/compiler/ast/core"
+import "github.com/nevalang/neva/pkg/core"
 
 // Helper is just a namespace for helper functions to avoid conflicts with entity types.
 // It's a stateless type and it's safe to share it between goroutines.

--- a/internal/compiler/typesystem/resolver.go
+++ b/internal/compiler/typesystem/resolver.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var (
@@ -166,6 +166,7 @@ func (r Resolver) CheckArgsCompatibility(args []Expr, params []Param, scope Scop
 // For non-native types process starts from the beginning with updated scope. New scope will contain values for params.
 // For lit exprs logic is the this:
 // for struct and union apply recursion for it's every field/element.
+//
 //nolint:gocyclo // Resolver covers many expression shapes and recursive cases.
 func (r Resolver) resolveExpr(
 	expr Expr, // expression to be resolved

--- a/internal/compiler/typesystem/resolver_test.go
+++ b/internal/compiler/typesystem/resolver_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var errTest = errors.New("oops")

--- a/internal/compiler/typesystem/scope_test.go
+++ b/internal/compiler/typesystem/scope_test.go
@@ -4,8 +4,8 @@ package typesystem_test
 import (
 	"errors"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var ErrDefaultScope = errors.New("default scope")

--- a/internal/compiler/typesystem/subtype_checker.go
+++ b/internal/compiler/typesystem/subtype_checker.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var (
@@ -33,6 +33,7 @@ type TerminatorParams struct {
 
 // Check checks whether subtype is a subtype of supertype. Both subtype and supertype must be resolved.
 // It also takes traces for those expressions and scope to handle recursive types.
+//
 //nolint:gocyclo // Subtype checking has many structural cases.
 func (s SubtypeChecker) Check(
 	expr,

--- a/internal/compiler/typesystem/subtype_checker_test.go
+++ b/internal/compiler/typesystem/subtype_checker_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/compiler/typesystem/terminator.go
+++ b/internal/compiler/typesystem/terminator.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var (

--- a/internal/compiler/typesystem/terminator_test.go
+++ b/internal/compiler/typesystem/terminator_test.go
@@ -3,8 +3,8 @@ package typesystem_test
 import (
 	"testing"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/compiler/typesystem/trace.go
+++ b/internal/compiler/typesystem/trace.go
@@ -1,7 +1,7 @@
 package typesystem
 
 import (
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // Linked-list to handle recursive types

--- a/internal/compiler/typesystem/trace_test.go
+++ b/internal/compiler/typesystem/trace_test.go
@@ -3,8 +3,8 @@ package typesystem_test
 import (
 	"testing"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/compiler/typesystem/typesystem.go
+++ b/internal/compiler/typesystem/typesystem.go
@@ -6,7 +6,7 @@ package typesystem
 import (
 	"sort"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 //nolint:govet // fieldalignment: keep semantic grouping.

--- a/internal/compiler/typesystem/typesystem_test.go
+++ b/internal/compiler/typesystem/typesystem_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 var h ts.Helper

--- a/internal/compiler/typesystem/validator_test.go
+++ b/internal/compiler/typesystem/validator_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func TestValidator_Validate(t *testing.T) {

--- a/internal/compiler/utils.go
+++ b/internal/compiler/utils.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	neva "github.com/nevalang/neva/internal/compiler/utils/generated"
 	"github.com/nevalang/neva/internal/runtime"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 //go:generate neva build --target=go --target-go-mode=pkg --target-go-runtime-path=../runtime --output=utils/generated utils

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"testing"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 func TestPackage_GetInteropableComponents(t *testing.T) {

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -5,8 +5,8 @@ package ast
 import (
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // Build represents all the information in source code, that must be compiled.

--- a/pkg/ast/scope.go
+++ b/pkg/ast/scope.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nevalang/neva/internal/compiler/ast/core"
 	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	"github.com/nevalang/neva/pkg"
+	"github.com/nevalang/neva/pkg/core"
 )
 
 // NewScope returns a new scope with a given location
@@ -18,6 +18,7 @@ func NewScope(build Build, location core.Location) Scope {
 }
 
 // Scope is entity reference resolver
+//
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Scope struct {
 	loc   core.Location

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -23,11 +23,12 @@ func (e EntityRef) String() string {
 }
 
 // Meta contains meta information about the source code
+//
 //nolint:govet // fieldalignment: keep order for readability and JSON grouping.
 type Meta struct {
-	Text     string   `json:"text,omitempty"`
-	Start    Position `json:"start,omitempty"`
-	Stop     Position `json:"stop,omitempty"`
+	Text  string   `json:"text,omitempty"`
+	Start Position `json:"start,omitempty"`
+	Stop  Position `json:"stop,omitempty"`
 	// Location must always be present, even for virtual nodes inserted after resugaring,
 	// because irgen relies on it.
 	Location Location `json:"location,omitempty"`


### PR DESCRIPTION
## Summary
- move compiler AST package from `internal/compiler/ast` to `pkg/ast`
- move shared core package from `internal/compiler/ast/core` to `pkg/core`
- update all compiler, builder, and LSP imports to use the new package locations
- add AGENTS session notes for the extraction/migration pattern

## Validation
- `golangci-lint run ./...`
- `go test ./pkg/... ./internal/compiler/... ./internal/builder/... ./cmd/lsp/... ./internal/cli/... ./cmd/neva/...`

## Notes
- I started `go test ./...` but stopped after it exceeded the 5-minute cap, then ran targeted suites covering moved packages and direct dependents.
