### PR TITLE
Expose public APIs for external LSP extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,8 @@ Follow these instructions.
 - **Architecture insights**: LSP workspace scanning moved into `pkg/indexer` as an explicit intermediate extraction step for splitting LSP out of the main repository.
 - **Common patterns**: Expose tooling-facing errors via a package-local adapter (`indexer.Error`) that wraps `compiler.Error` but stabilizes surfaced fields (`Message`, `Meta`) and behavior (`Error()`, `Unwrap()`).
 - **Gotchas**: LSP diagnostics code must guard `Meta == nil` when deriving URIs/ranges from indexer errors to avoid nil-pointer crashes.
+- **Architecture insights**: `pkg/indexer.NewDefault` centralizes default parser/builder/analyzer wiring, so LSP binaries can initialize indexing without importing `internal/*`.
+- **Architecture insights**: `pkg/typesystem` now re-exports core type-system types for tooling, allowing LSP code to stop importing `internal/compiler/typesystem` directly.
 
 ### Session Notes (2026-02-14, visual plan decisions)
 
@@ -204,7 +206,6 @@ Follow these instructions.
 - **Common patterns**: Prefer explicit `neva/get*` visual methods over reviving incomplete `resolve_file`/`GetFileView` bridge paths when no compatibility obligations exist.
 - **UI/UX patterns**: MVP IDE integration can start as a command-based readonly preview (Markdown-preview style) with component focus/fullscreen, while custom-editor/side-panel/inline variants stay as explicit follow-up decisions.
 - **Architecture insights**: Standalone visual app should depend on Neva LSP transport, not editor-specific APIs, so IDE and standalone consume the same graph contract.
-
 ## 3. ⚡ Core Concepts
 
 - **Dataflow**: Programs are graphs. Nodes process data; edges transport it.

--- a/cmd/lsp/main.go
+++ b/cmd/lsp/main.go
@@ -8,10 +8,6 @@ import (
 	"github.com/tliron/glsp/server"
 
 	lspServer "github.com/nevalang/neva/cmd/lsp/server"
-	builder "github.com/nevalang/neva/internal/builder"
-	"github.com/nevalang/neva/internal/compiler/analyzer"
-	"github.com/nevalang/neva/internal/compiler/parser"
-	"github.com/nevalang/neva/internal/compiler/typesystem"
 	"github.com/nevalang/neva/pkg/indexer"
 )
 
@@ -29,14 +25,7 @@ func main() {
 	commonlog.Configure(loglvl, nil)
 	logger := commonlog.GetLoggerf("%s.server", serverName)
 
-	p := parser.New()
-
-	terminator := typesystem.Terminator{}
-	checker := typesystem.MustNewSubtypeChecker(terminator)
-	resolver := typesystem.MustNewResolver(typesystem.Validator{}, checker, terminator)
-	builder := builder.MustNew(p)
-
-	indexer := indexer.New(builder, p, analyzer.MustNew(resolver), logger)
+	indexer := indexer.MustNewDefault(logger)
 
 	handler := lspServer.BuildHandler(logger, serverName, indexer)
 

--- a/cmd/lsp/server/lsp_features_test.go
+++ b/cmd/lsp/server/lsp_features_test.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"testing"
 
-	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	src "github.com/nevalang/neva/pkg/ast"
 	"github.com/nevalang/neva/pkg/core"
+	ts "github.com/nevalang/neva/pkg/typesystem"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/cmd/lsp/server/server.go
+++ b/cmd/lsp/server/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	"github.com/nevalang/neva/internal/compiler"
 	src "github.com/nevalang/neva/pkg/ast"
 	"github.com/nevalang/neva/pkg/indexer"
 )
@@ -136,13 +135,17 @@ func (s *Server) createDiagnostics(
 		Diagnostics: []protocol.Diagnostic{
 			{
 				Range:    startStopRange,
-				Severity: compiler.Pointer(protocol.DiagnosticSeverityError),
-				Source:   compiler.Pointer("compiler"),
+				Severity: ptr(protocol.DiagnosticSeverityError),
+				Source:   ptr("compiler"),
 				Message:  indexerErr.Message, // we don't use Error() because it will duplicate location
 				Data:     time.Now(),
 			},
 		},
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func toUint32(value int) uint32 {

--- a/cmd/lsp/server/symbols.go
+++ b/cmd/lsp/server/symbols.go
@@ -13,9 +13,9 @@ import (
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 
-	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	src "github.com/nevalang/neva/pkg/ast"
 	"github.com/nevalang/neva/pkg/core"
+	ts "github.com/nevalang/neva/pkg/typesystem"
 )
 
 type fileContext struct {

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"testing"
 
-	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	"github.com/nevalang/neva/pkg/core"
+	ts "github.com/nevalang/neva/pkg/typesystem"
 )
 
 func TestPackage_GetInteropableComponents(t *testing.T) {

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -5,8 +5,8 @@ package ast
 import (
 	"fmt"
 
-	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	"github.com/nevalang/neva/pkg/core"
+	ts "github.com/nevalang/neva/pkg/typesystem"
 )
 
 // Build represents all the information in source code, that must be compiled.

--- a/pkg/ast/scope.go
+++ b/pkg/ast/scope.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	ts "github.com/nevalang/neva/internal/compiler/typesystem"
 	"github.com/nevalang/neva/pkg"
 	"github.com/nevalang/neva/pkg/core"
+	ts "github.com/nevalang/neva/pkg/typesystem"
 )
 
 // NewScope returns a new scope with a given location

--- a/pkg/indexer/default.go
+++ b/pkg/indexer/default.go
@@ -1,0 +1,35 @@
+package indexer
+
+import (
+	"github.com/tliron/commonlog"
+
+	"github.com/nevalang/neva/internal/builder"
+	"github.com/nevalang/neva/internal/compiler/analyzer"
+	"github.com/nevalang/neva/internal/compiler/parser"
+	"github.com/nevalang/neva/internal/compiler/typesystem"
+)
+
+// NewDefault creates an Indexer with default compiler frontend dependencies.
+func NewDefault(logger commonlog.Logger) (Indexer, error) {
+	p := parser.New()
+
+	terminator := typesystem.Terminator{}
+	checker := typesystem.MustNewSubtypeChecker(terminator)
+	resolver := typesystem.MustNewResolver(typesystem.Validator{}, checker, terminator)
+
+	b, err := builder.New(p)
+	if err != nil {
+		return Indexer{}, err
+	}
+
+	return New(b, p, analyzer.MustNew(resolver), logger), nil
+}
+
+// MustNewDefault creates an Indexer with default dependencies and panics on error.
+func MustNewDefault(logger commonlog.Logger) Indexer {
+	idx, err := NewDefault(logger)
+	if err != nil {
+		panic(err)
+	}
+	return idx
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -1,0 +1,37 @@
+// Package typesystem re-exports Neva type-system structures for external tooling.
+package typesystem
+
+import ts "github.com/nevalang/neva/internal/compiler/typesystem"
+
+type (
+	Def              = ts.Def
+	Param            = ts.Param
+	Expr             = ts.Expr
+	InstExpr         = ts.InstExpr
+	LitExpr          = ts.LitExpr
+	LiteralType      = ts.LiteralType
+	Scope            = ts.Scope
+	Resolver         = ts.Resolver
+	Validator        = ts.Validator
+	Terminator       = ts.Terminator
+	SubtypeChecker   = ts.SubtypeChecker
+	TerminatorParams = ts.TerminatorParams
+)
+
+const (
+	EmptyLitType  = ts.EmptyLitType
+	StructLitType = ts.StructLitType
+	UnionLitType  = ts.UnionLitType
+)
+
+func MustNewResolver(
+	validator Validator,
+	checker SubtypeChecker,
+	terminator Terminator,
+) Resolver {
+	return ts.MustNewResolver(validator, checker, terminator)
+}
+
+func MustNewSubtypeChecker(terminator Terminator) SubtypeChecker {
+	return ts.MustNewSubtypeChecker(terminator)
+}


### PR DESCRIPTION
## Summary
- add pkg/indexer.NewDefault / MustNewDefault to initialize indexing without importing internal compiler packages
- add pkg/typesystem to re-export type-system types for tooling consumers
- switch pkg/ast to import pkg/typesystem instead of internal/compiler/typesystem
- update cmd/lsp to avoid internal imports in startup and symbols traversal
- keep AGENTS session notes in sync with extraction changes

## Validation
- golangci-lint run ./...
- go test ./cmd/lsp/... ./pkg/indexer ./pkg/typesystem ./pkg/ast
- go test ./... (long e2e run progressed through most suites in this environment; output stream stalled near tail as seen previously)
