### PR TITLE
chore: migrate repo to Go 1.26 and add gofix CI check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,10 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.6'
+          go-version: '1.26.0'
           cache: false
+      - name: gofix-check
+        run: make gofix-check
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.6'
+        go-version: '1.26.0'
     - name: install
       run: |
         go install ./cmd/neva

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,12 @@ Follow these instructions.
 - **Common patterns**: Keep collection converters in `target-package + FromSource` shape (`streams.FromDict`, `dicts.FromStream`) for consistency with existing list/stream APIs.
 - **Language semantics**: `dicts.FromStream` uses last-write-wins for duplicate keys by assigning incoming entries into the resulting dict.
 - **Gotchas**: `streams.FromDict` iterates Go maps, so output stream order is non-deterministic and should not be asserted directly in tests.
+
+### Session Notes (2026-02-24)
+
+- **Common patterns**: For Go 1.26 migration, keep `go.mod` (`go` + `toolchain`) and CI `actions/setup-go` patch versions aligned to avoid toolchain skew.
+- **Common patterns**: Integrate `go fix` as a dedicated CI check (`go fix ./...` + `git diff --exit-code`) so failures clearly signal "run gofix and commit".
+- **Gotchas**: `go fix` can apply broad modernizations in one pass; run lint/tests immediately after and fix secondary lints introduced by rewrites.
 ## 3. ⚡ Core Concepts
 
 - **Dataflow**: Programs are graphs. Nodes process data; edges transport it.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,17 @@ antlr:
 betteralign-fix:
 	betteralign -fix ./...
 
+# apply gofix rewrites across the repo
+.PHONY: gofix
+gofix:
+	go fix ./...
+
+# check that gofix produces no diff (CI-friendly)
+.PHONY: gofix-check
+gofix-check:
+	go fix ./...
+	git diff --exit-code
+
 # check potential nil-derefs
 .PHONY: nilaway
 nilaway:

--- a/e2e/for_with_range_and_if/e2e_test.go
+++ b/e2e/for_with_range_and_if/e2e_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		t.Run("", func(t *testing.T) {
 			out, _ := e2e.Run(t, []string{"run", "main"})
 			require.Equal(

--- a/e2e/map_list_verbose/e2e_test.go
+++ b/e2e/map_list_verbose/e2e_test.go
@@ -10,7 +10,7 @@ import (
 func Test(t *testing.T) {
 	// we do 10 iterations because there was a bug
 	// that was only reproducible after a few runs
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		out, _ := e2e.Run(t, []string{"run", "main"})
 		require.Equal(
 			t,

--- a/e2e/order_dependend_with_arr_inport/e2e_test.go
+++ b/e2e/order_dependend_with_arr_inport/e2e_test.go
@@ -10,7 +10,7 @@ import (
 func Test(t *testing.T) {
 	// we do 100 attempts because there was a floating bug
 	// caused by unordered map that was
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		out, _ := e2e.Run(t, []string{"run", "main"})
 		require.Equal(
 			t,

--- a/examples/add_numbers/e2e_test.go
+++ b/examples/add_numbers/e2e_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		out, _ := e2e.Run(t, []string{"run", "."})
 		require.Equal(
 			t,

--- a/examples/for_loop_over_list/e2e_test.go
+++ b/examples/for_loop_over_list/e2e_test.go
@@ -11,7 +11,7 @@ import (
 func Test(t *testing.T) {
 	// We do 100 attempts to prove that implementation is correct
 	// and order of elements is always the same.
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		t.Run(fmt.Sprintf("Iteration %d", i), func(t *testing.T) {
 			out, _ := e2e.Run(t, []string{"run", "."})
 			require.Equal(

--- a/examples/match/e2e_test.go
+++ b/examples/match/e2e_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		out, _ := e2e.Run(t, []string{"run", "."})
 		require.Equal(
 			t,

--- a/examples/select/e2e_test.go
+++ b/examples/select/e2e_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		t.Logf("Running iteration %d", i)
 		out, _ := e2e.Run(t, []string{"run", "."})
 		require.Equal(

--- a/examples/stream_zip/e2e_test.go
+++ b/examples/stream_zip/e2e_test.go
@@ -14,7 +14,7 @@ func Test(t *testing.T) {
 {"left": 2, "right": "c"}
 `
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		t.Run(fmt.Sprintf("Iteration %d", i), func(t *testing.T) {
 			out, _ := e2e.Run(t, []string{"run", "."})
 			require.Equal(t, expectedOutput, out)

--- a/examples/stream_zip_many/e2e_test.go
+++ b/examples/stream_zip_many/e2e_test.go
@@ -14,7 +14,7 @@ func Test(t *testing.T) {
 [3,30,300]
 `
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		t.Run(fmt.Sprintf("Iteration %d", i), func(t *testing.T) {
 			out, _ := e2e.Run(t, []string{"run", "."})
 			require.Equal(t, expectedOutput, out)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nevalang/neva
 
-go 1.25
+go 1.26
 
-toolchain go1.25.6
+toolchain go1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/internal/builder/lock.go
+++ b/internal/builder/lock.go
@@ -26,7 +26,7 @@ func acquireLockFile() (release func(), err error) {
 
 	filename := filepath.Join(home, "neva", ".lock")
 
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		f, err := os.OpenFile(
 			filename,
 			os.O_CREATE|os.O_EXCL,

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -157,10 +157,7 @@ func searchStdlib(pkgPath string, re *regexp.Regexp, context int) ([]docMatch, e
 				continue
 			}
 
-			start := i - context
-			if start < 0 {
-				start = 0
-			}
+			start := max(i-context, 0)
 			end := i + context
 			if end >= len(lines) {
 				end = len(lines) - 1

--- a/internal/cli/osarch.go
+++ b/internal/cli/osarch.go
@@ -23,8 +23,8 @@ func newOSArchCmd() *cli.Command {
 			fmt.Println("(use these values for --target-os and --target-arch flags when cross-compiling)")
 			fmt.Println()
 
-			platforms := strings.Split(strings.TrimSpace(string(output)), "\n")
-			for _, platform := range platforms {
+			platforms := strings.SplitSeq(strings.TrimSpace(string(output)), "\n")
+			for platform := range platforms {
 				fmt.Println(platform)
 			}
 

--- a/internal/compiler/backend/golang/backend.go
+++ b/internal/compiler/backend/golang/backend.go
@@ -452,7 +452,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 	case ir.MsgTypeDict:
 		keyValuePairs := make([]string, 0, len(msg.DictOrStruct))
 		for k, v := range msg.DictOrStruct {
-			el, err := b.getMessageString(compiler.Pointer(v))
+			el, err := b.getMessageString(new(v))
 			if err != nil {
 				return "", err
 			}
@@ -462,7 +462,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 	case ir.MsgTypeStruct:
 		fields := make([]string, 0, len(msg.DictOrStruct))
 		for k, v := range msg.DictOrStruct {
-			el, err := b.getMessageString(compiler.Pointer(v))
+			el, err := b.getMessageString(new(v))
 			if err != nil {
 				return "", err
 			}

--- a/internal/compiler/backend/ir/mermaid/backend.go
+++ b/internal/compiler/backend/ir/mermaid/backend.go
@@ -18,13 +18,13 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 	// Format: // module=@@ main=hello_world compiler=0.34.0
 	var modName, compilerVer string
 	if strings.HasPrefix(prog.Comment, "//") {
-		parts := strings.Fields(prog.Comment)
-		for _, p := range parts {
-			if strings.HasPrefix(p, "main=") {
-				modName = strings.TrimPrefix(p, "main=")
+		parts := strings.FieldsSeq(prog.Comment)
+		for p := range parts {
+			if after, ok := strings.CutPrefix(p, "main="); ok {
+				modName = after
 			}
-			if strings.HasPrefix(p, "compiler=") {
-				compilerVer = strings.TrimPrefix(p, "compiler=")
+			if after, ok := strings.CutPrefix(p, "compiler="); ok {
+				compilerVer = after
 			}
 		}
 	}
@@ -120,10 +120,10 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 
 		// Trim /in and /out from path to get component path
 		path := addr.Path
-		if strings.HasSuffix(path, "/in") {
-			path = strings.TrimSuffix(path, "/in")
-		} else if strings.HasSuffix(path, "/out") {
-			path = strings.TrimSuffix(path, "/out")
+		if before, ok := strings.CutSuffix(path, "/in"); ok {
+			path = before
+		} else if before, ok := strings.CutSuffix(path, "/out"); ok {
+			path = before
 		}
 
 		n := getOrCreateNode(path)
@@ -149,10 +149,10 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 		for _, addr := range f.IO.In {
 			// Try to find component path from port address
 			path := addr.Path
-			if strings.HasSuffix(path, "/in") {
-				path = strings.TrimSuffix(path, "/in")
-			} else if strings.HasSuffix(path, "/out") {
-				path = strings.TrimSuffix(path, "/out")
+			if before, ok := strings.CutSuffix(path, "/in"); ok {
+				path = before
+			} else if before, ok := strings.CutSuffix(path, "/out"); ok {
+				path = before
 			}
 			if path != "" {
 				matchPath = path
@@ -164,10 +164,10 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 		if matchPath == "" {
 			for _, addr := range f.IO.Out {
 				path := addr.Path
-				if strings.HasSuffix(path, "/in") {
-					path = strings.TrimSuffix(path, "/in")
-				} else if strings.HasSuffix(path, "/out") {
-					path = strings.TrimSuffix(path, "/out")
+				if before, ok := strings.CutSuffix(path, "/in"); ok {
+					path = before
+				} else if before, ok := strings.CutSuffix(path, "/out"); ok {
+					path = before
 				}
 				if path != "" {
 					matchPath = path
@@ -348,10 +348,10 @@ func getPortID(addr ir.PortAddr) string {
 	}
 
 	path := addr.Path
-	if strings.HasSuffix(path, "/in") {
-		path = strings.TrimSuffix(path, "/in")
-	} else if strings.HasSuffix(path, "/out") {
-		path = strings.TrimSuffix(path, "/out")
+	if before, ok := strings.CutSuffix(path, "/in"); ok {
+		path = before
+	} else if before, ok := strings.CutSuffix(path, "/out"); ok {
+		path = before
 	}
 
 	return sanitize(path) + "__" + sanitize(addr.Port)

--- a/internal/compiler/backend/ir/threejs/backend.go
+++ b/internal/compiler/backend/ir/threejs/backend.go
@@ -69,8 +69,8 @@ func prepareData(prog *ir.Program) (templateData, error) {
 	// Helper to normalize node names
 	getNodeName := func(path string) string {
 		for _, suffix := range []string{"/in", "/out"} {
-			if strings.HasSuffix(path, suffix) {
-				return strings.TrimSuffix(path, suffix)
+			if before, ok := strings.CutSuffix(path, suffix); ok {
+				return before
 			}
 		}
 		return path

--- a/internal/compiler/desugarer/const.go
+++ b/internal/compiler/desugarer/const.go
@@ -1,7 +1,6 @@
 package desugarer
 
 import (
-	"github.com/nevalang/neva/internal/compiler"
 	src "github.com/nevalang/neva/pkg/ast"
 )
 
@@ -20,7 +19,7 @@ func (d *Desugarer) handleConst(constant src.Const) src.Const {
 		TypeExpr: constant.TypeExpr,
 		Value: src.ConstValue{
 			Message: &src.MsgLiteral{
-				Float: compiler.Pointer(float64(*constant.Value.Message.Int)),
+				Float: new(float64(*constant.Value.Message.Int)),
 				Meta:  constant.Meta,
 			},
 		},

--- a/internal/compiler/desugarer/desugarer.go
+++ b/internal/compiler/desugarer/desugarer.go
@@ -136,9 +136,7 @@ func (d *Desugarer) desugarFile(
 		desugaredEntities[entityName] = entityResult.entity
 
 		// insert virtual entities, created by desugaring of the entity
-		for name, entityToInsert := range entityResult.insert {
-			desugaredEntities[name] = entityToInsert
-		}
+		maps.Copy(desugaredEntities, entityResult.insert)
 	}
 
 	desugaredImports := maps.Clone(file.Imports)

--- a/internal/compiler/desugarer/network.go
+++ b/internal/compiler/desugarer/network.go
@@ -843,7 +843,7 @@ func (d *Desugarer) desugarFanOut(
 					PortAddr: &src.PortAddr{
 						Node: nodeName,
 						Port: "data",
-						Idx:  compiler.Pointer(uint8(i)), // #nosec G115 -- bounds checked above
+						Idx:  new(uint8(i)), // #nosec G115 -- bounds checked above
 						Meta: locOnlyMeta,
 					},
 					Meta: locOnlyMeta,
@@ -919,7 +919,7 @@ func (d *Desugarer) desugarFanIn(
 					PortAddr: &src.PortAddr{
 						Node: fanInNodeName,
 						Port: "data",
-						Idx:  compiler.Pointer(uint8(i)), // #nosec G115 -- bounds checked above
+						Idx:  new(uint8(i)), // #nosec G115 -- bounds checked above
 						Meta: locOnlyMeta,
 					},
 					Meta: locOnlyMeta,

--- a/internal/compiler/desugarer/network_test.go
+++ b/internal/compiler/desugarer/network_test.go
@@ -94,7 +94,7 @@ func TestDesugarNetwork(t *testing.T) {
 						},
 						Receivers: []src.ConnectionReceiver{
 							{
-								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: compiler.Pointer(uint8(0))},
+								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: new(uint8(0))},
 							},
 						},
 					},
@@ -106,7 +106,7 @@ func TestDesugarNetwork(t *testing.T) {
 						},
 						Receivers: []src.ConnectionReceiver{
 							{
-								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: compiler.Pointer(uint8(1))},
+								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: new(uint8(1))},
 							},
 						},
 					},
@@ -170,7 +170,7 @@ func TestDesugarNetwork(t *testing.T) {
 						},
 						Receivers: []src.ConnectionReceiver{
 							{
-								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: compiler.Pointer(uint8(0))},
+								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: new(uint8(0))},
 							},
 						},
 					},
@@ -182,7 +182,7 @@ func TestDesugarNetwork(t *testing.T) {
 						},
 						Receivers: []src.ConnectionReceiver{
 							{
-								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: compiler.Pointer(uint8(1))},
+								PortAddr: &src.PortAddr{Node: "__fan_in__1", Port: "data", Idx: new(uint8(1))},
 							},
 						},
 					},
@@ -351,9 +351,9 @@ func TestDesugarNetwork(t *testing.T) {
 						Value: src.ConstValue{
 							Message: &src.MsgLiteral{
 								List: []src.ConstValue{
-									{Message: &src.MsgLiteral{Str: compiler.Pointer("a")}},
-									{Message: &src.MsgLiteral{Str: compiler.Pointer("b")}},
-									{Message: &src.MsgLiteral{Str: compiler.Pointer("c")}},
+									{Message: &src.MsgLiteral{Str: new("a")}},
+									{Message: &src.MsgLiteral{Str: new("b")}},
+									{Message: &src.MsgLiteral{Str: new("c")}},
 								},
 							},
 						},
@@ -392,7 +392,7 @@ func TestDesugarNetwork(t *testing.T) {
 						Inst: &ts.InstExpr{Ref: core.EntityRef{Name: "int"}},
 					},
 					Value: src.ConstValue{
-						Message: &src.MsgLiteral{Int: compiler.Pointer(42)},
+						Message: &src.MsgLiteral{Int: new(42)},
 					},
 				}
 				mock.
@@ -474,7 +474,7 @@ func TestDesugarNetwork(t *testing.T) {
 						Inst: &ts.InstExpr{Ref: core.EntityRef{Name: "int"}},
 					},
 					Value: src.ConstValue{
-						Message: &src.MsgLiteral{Int: compiler.Pointer(42)},
+						Message: &src.MsgLiteral{Int: new(42)},
 					},
 				}
 				mock.
@@ -548,7 +548,7 @@ func TestDesugarNetwork(t *testing.T) {
 												},
 											},
 											Value: src.ConstValue{
-												Message: &src.MsgLiteral{Int: compiler.Pointer(42)},
+												Message: &src.MsgLiteral{Int: new(42)},
 											},
 										},
 									},
@@ -617,7 +617,7 @@ func TestDesugarNetwork(t *testing.T) {
 							},
 						},
 						Value: src.ConstValue{
-							Message: &src.MsgLiteral{Int: compiler.Pointer(42)},
+							Message: &src.MsgLiteral{Int: new(42)},
 						},
 					},
 				},
@@ -724,7 +724,7 @@ func TestDesugarNetwork(t *testing.T) {
 											Tag:       "Int",
 											Data: &src.ConstValue{
 												Message: &src.MsgLiteral{
-													Int: compiler.Pointer(42),
+													Int: new(42),
 												},
 											},
 										},
@@ -787,7 +787,7 @@ func TestDesugarNetwork(t *testing.T) {
 									Tag:       "Int",
 									Data: &src.ConstValue{
 										Message: &src.MsgLiteral{
-											Int: compiler.Pointer(42),
+											Int: new(42),
 										},
 									},
 								},

--- a/internal/compiler/desugarer/struct_selectors.go
+++ b/internal/compiler/desugarer/struct_selectors.go
@@ -90,7 +90,7 @@ func (Desugarer) createSelectorCfgMsg(senderSide src.ConnectionSender) src.Const
 	for _, selector := range senderSide.StructSelector {
 		result = append(result, src.ConstValue{
 			Message: &src.MsgLiteral{
-				Str:  compiler.Pointer(selector),
+				Str:  new(selector),
 				Meta: locOnlyMeta,
 			},
 		})

--- a/internal/compiler/ir/ir.go
+++ b/internal/compiler/ir/ir.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Program is a graph where ports are vertexes and connections are edges.
+//
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Program struct {
 	Connections map[PortAddr]PortAddr `json:"-" yaml:"-"` // Hide from default marshaling
@@ -84,6 +85,7 @@ func (p PortAddr) MarshalYAML() (any, error) {
 }
 
 // FuncCall describes call of a runtime function.
+//
 //nolint:govet // fieldalignment: keep semantic grouping.
 type FuncCall struct {
 	Ref string   `json:"ref,omitempty" yaml:"ref,omitempty"` // Reference to the function in registry.
@@ -98,6 +100,7 @@ type FuncIO struct {
 }
 
 // Message is a data that can be sent and received.
+//
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Message struct {
 	Type         MsgType            `json:"type" yaml:"type"`
@@ -107,7 +110,7 @@ type Message struct {
 	String       string             `json:"str,omitempty" yaml:"str,omitempty"`
 	List         []Message          `json:"list,omitempty" yaml:"list,omitempty"`
 	DictOrStruct map[string]Message `json:"map,omitempty" yaml:"map,omitempty"`
-	Union        UnionMessage       `json:"union,omitempty" yaml:"union,omitempty"`
+	Union        UnionMessage       `json:"union" yaml:"union,omitempty"`
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.

--- a/internal/compiler/irgen/network.go
+++ b/internal/compiler/irgen/network.go
@@ -279,7 +279,7 @@ func (g Generator) processReceiver(
 }
 
 func joinNodePath(nodePath []string, nodeName string) string {
-	newPath := make([]string, len(nodePath))
+	newPath := make([]string, len(nodePath), len(nodePath)+1)
 	copy(newPath, nodePath)
 	newPath = append(newPath, nodeName)
 	return strings.Join(newPath, "/")

--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -818,7 +818,7 @@ func (s *treeShapeListener) parseMessage(
 				},
 			}
 		}
-		msg.Bool = compiler.Pointer(boolVal == "true")
+		msg.Bool = new(boolVal == "true")
 	case constVal.INT() != nil:
 		parsedInt, err := strconv.ParseInt(constVal.INT().GetText(), 10, 64)
 		if err != nil {
@@ -841,7 +841,7 @@ func (s *treeShapeListener) parseMessage(
 		if constVal.MINUS() != nil {
 			parsedInt = -parsedInt
 		}
-		msg.Int = compiler.Pointer(int(parsedInt))
+		msg.Int = new(int(parsedInt))
 	case constVal.FLOAT() != nil:
 		parsedFloat, err := strconv.ParseFloat(constVal.FLOAT().GetText(), 64)
 		if err != nil {
@@ -866,7 +866,7 @@ func (s *treeShapeListener) parseMessage(
 		}
 		msg.Float = &parsedFloat
 	case constVal.STRING() != nil:
-		msg.Str = compiler.Pointer(
+		msg.Str = new(
 			strings.Trim(
 				strings.ReplaceAll(
 					constVal.STRING().GetText(),
@@ -1000,7 +1000,7 @@ func (s *treeShapeListener) parseTypeDef(
 		if err != nil {
 			return src.Entity{}, err
 		}
-		body = compiler.Pointer(v)
+		body = new(v)
 	}
 
 	v, err := s.parseTypeParams(actx.TypeParams())

--- a/internal/compiler/parser/parser_test.go
+++ b/internal/compiler/parser/parser_test.go
@@ -65,12 +65,12 @@ func TestParser_ParseFile_PortlessArrPortAddr(t *testing.T) {
 	// foo[0]->
 	require.Equal(t, "foo", conn.Senders[0].PortAddr.Node)
 	require.Equal(t, "", conn.Senders[0].PortAddr.Port)
-	require.Equal(t, compiler.Pointer(uint8(0)), conn.Senders[0].PortAddr.Idx)
+	require.Equal(t, new(uint8(0)), conn.Senders[0].PortAddr.Idx)
 
 	// ->bar[1]
 	require.Equal(t, "bar", conn.Receivers[0].PortAddr.Node)
 	require.Equal(t, "", conn.Receivers[0].PortAddr.Port)
-	require.Equal(t, compiler.Pointer(uint8(1)), conn.Receivers[0].PortAddr.Idx)
+	require.Equal(t, new(uint8(1)), conn.Receivers[0].PortAddr.Idx)
 }
 
 func TestParser_ParseFile_ArrayBypassIdx(t *testing.T) {

--- a/internal/compiler/parser/smoke_test/smoke_test.go
+++ b/internal/compiler/parser/smoke_test/smoke_test.go
@@ -28,6 +28,7 @@ type MyErrorListener interface {
 }
 
 // FileAwareErrorListener provides better error reporting with file context
+//
 //nolint:govet // fieldalignment: small helper struct.
 type FileAwareErrorListener struct {
 	filename string
@@ -42,7 +43,7 @@ func NewFileAwareErrorListener(t *testing.T, filename string) *FileAwareErrorLis
 	}
 }
 
-func (f *FileAwareErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+func (f *FileAwareErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol any, line, column int, msg string, e antlr.RecognitionException) {
 	tokenText := "<unknown>"
 	if token, ok := offendingSymbol.(antlr.Token); ok {
 		tokenText = token.GetText()

--- a/internal/compiler/typesystem/trace.go
+++ b/internal/compiler/typesystem/trace.go
@@ -1,6 +1,8 @@
 package typesystem
 
 import (
+	"strings"
+
 	"github.com/nevalang/neva/pkg/core"
 )
 
@@ -20,15 +22,16 @@ func (t Trace) String() string {
 		tmp = tmp.prev
 	}
 
-	firstToLast := "["
+	var firstToLast strings.Builder
+	firstToLast.WriteString("[")
 	for i := len(lastToFirst) - 1; i >= 0; i-- {
-		firstToLast += lastToFirst[i].String()
+		firstToLast.WriteString(lastToFirst[i].String())
 		if i > 0 {
-			firstToLast += ", "
+			firstToLast.WriteString(", ")
 		}
 	}
 
-	return firstToLast + "]"
+	return firstToLast.String() + "]"
 }
 
 func NewTrace(prev *Trace, cur core.EntityRef) Trace {

--- a/internal/compiler/utils.go
+++ b/internal/compiler/utils.go
@@ -12,8 +12,10 @@ import (
 //go:generate neva build --target=go --target-go-mode=pkg --target-go-runtime-path=../runtime --output=utils/generated utils
 
 // Pointer allows to avoid creating of temporary variables just to take pointers.
+//
+//go:fix inline
 func Pointer[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 // ParseEntityRef calls Neva and marshals result into core.EntityRef.

--- a/internal/runtime/funcs/arr_port_to_list.go
+++ b/internal/runtime/funcs/arr_port_to_list.go
@@ -28,7 +28,7 @@ func (arrayPortToList) Create(
 
 		for {
 			list := make([]runtime.Msg, 0, l)
-			for idx := 0; idx < l; idx++ {
+			for idx := range l {
 				msg, ok := portIn.Receive(ctx, idx)
 				if !ok {
 					return

--- a/internal/runtime/funcs/arr_port_to_stream.go
+++ b/internal/runtime/funcs/arr_port_to_stream.go
@@ -29,7 +29,7 @@ func (arrayPortToStream) Create(
 		l := portIn.Len()
 
 		for {
-			for idx := 0; idx < l; idx++ {
+			for idx := range l {
 				msg, ok := portIn.Receive(ctx, idx)
 				if !ok {
 					return

--- a/internal/runtime/funcs/dotenv_load.go
+++ b/internal/runtime/funcs/dotenv_load.go
@@ -100,6 +100,7 @@ func (d dotenvLoad) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Cont
 }
 
 func loadDotenvFile(path string, override bool) error {
+	// #nosec G304,G703 -- path comes from explicit component input (caller-controlled by design).
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -145,8 +146,8 @@ func parseDotenv(r io.Reader) (map[string]string, error) {
 			continue
 		}
 
-		if strings.HasPrefix(line, "export ") {
-			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		if after, ok := strings.CutPrefix(line, "export "); ok {
+			line = strings.TrimSpace(after)
 		}
 
 		key, value, err := parseDotenvEntry(line)

--- a/internal/runtime/funcs/int_pow.go
+++ b/internal/runtime/funcs/int_pow.go
@@ -54,7 +54,7 @@ func (intPow) Create(
 			exp := elMsg.Int()
 			result := int64(1)
 
-			for i := int64(0); i < exp; i++ {
+			for range exp {
 				result *= base
 			}
 

--- a/internal/runtime/funcs/list_to_stream.go
+++ b/internal/runtime/funcs/list_to_stream.go
@@ -31,7 +31,7 @@ func (c listToStream) Create(
 
 			list := data.List()
 
-			for idx := 0; idx < len(list); idx++ {
+			for idx := range list {
 				item := streamItem(
 					list[idx],
 					int64(idx),

--- a/internal/runtime/funcs/printf.go
+++ b/internal/runtime/funcs/printf.go
@@ -113,7 +113,7 @@ func format(tpl string, args []runtime.Msg) (string, error) {
 				usedArgs[argIndex] = true
 
 				// Replace the placeholder with the argument's string representation
-				result.WriteString(fmt.Sprint(args[argIndex]))
+				fmt.Fprint(&result, args[argIndex])
 
 				// Move past the current placeholder in the template
 				i = j

--- a/internal/runtime/funcs/stream_zip_many.go
+++ b/internal/runtime/funcs/stream_zip_many.go
@@ -42,7 +42,7 @@ func (streamZipMany) Create(
 			var wg sync.WaitGroup
 			wg.Add(streamsCount)
 
-			for streamIdx := 0; streamIdx < streamsCount; streamIdx++ {
+			for streamIdx := range streamsCount {
 				idx := streamIdx
 
 				go func() {
@@ -84,7 +84,7 @@ func (streamZipMany) Create(
 
 			for idx := 0; idx < count; idx++ {
 				zipped := make([]runtime.Msg, streamsCount)
-				for streamIdx := 0; streamIdx < streamsCount; streamIdx++ {
+				for streamIdx := range streamsCount {
 					zipped[streamIdx] = states[streamIdx].data[idx]
 				}
 

--- a/internal/runtime/message.go
+++ b/internal/runtime/message.go
@@ -355,7 +355,7 @@ func (msg UnionMsg) String() string {
 
 func (msg UnionMsg) MarshalJSON() ([]byte, error) {
 	if msg.data == nil {
-		return []byte(fmt.Sprintf(`{ "tag": %q }`, msg.tag)), nil
+		return fmt.Appendf(nil, `{ "tag": %q }`, msg.tag), nil
 	}
 
 	dataJSON, err := json.Marshal(msg.data)
@@ -364,7 +364,7 @@ func (msg UnionMsg) MarshalJSON() ([]byte, error) {
 	}
 	dataJSON = addJSONSpaces(dataJSON)
 
-	return []byte(fmt.Sprintf(`{ "tag": %q, "data": %s }`, msg.tag, dataJSON)), nil
+	return fmt.Appendf(nil, `{ "tag": %q, "data": %s }`, msg.tag, dataJSON), nil
 }
 
 // Uint8Index validates idx and returns it as uint8 or panics.

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -4,6 +4,7 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nevalang/neva/pkg/core"
 	ts "github.com/nevalang/neva/pkg/typesystem"
@@ -14,13 +15,13 @@ import (
 //
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Build struct {
-	EntryModRef core.ModuleRef            `json:"entryModRef,omitempty"`
+	EntryModRef core.ModuleRef            `json:"entryModRef"`
 	Modules     map[core.ModuleRef]Module `json:"modules,omitempty"`
 }
 
 // Module is unit of distribution.
 type Module struct {
-	Manifest ModuleManifest     `json:"manifest,omitempty"`
+	Manifest ModuleManifest     `json:"manifest"`
 	Packages map[string]Package `json:"packages,omitempty"`
 }
 
@@ -88,16 +89,16 @@ type File struct {
 type Import struct {
 	Module  string    `json:"moduleName,omitempty"`
 	Package string    `json:"pkgName,omitempty"`
-	Meta    core.Meta `json:"meta,omitempty"`
+	Meta    core.Meta `json:"meta"`
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Entity struct {
 	IsPublic  bool        `json:"exported,omitempty"`
 	Kind      EntityKind  `json:"kind,omitempty"`
-	Const     Const       `json:"const,omitempty"`
-	Type      ts.Def      `json:"type,omitempty"`
-	Interface Interface   `json:"interface,omitempty"`
+	Const     Const       `json:"const"`
+	Type      ts.Def      `json:"type"`
+	Interface Interface   `json:"interface"`
 	Component []Component `json:"component,omitempty"` // Non-overloaded components are represented as slice of one element.
 }
 
@@ -129,11 +130,11 @@ const (
 //
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Component struct {
-	Interface  `json:"interface,omitempty"`
+	Interface  `json:"interface"`
 	Directives map[Directive]string `json:"directives,omitempty"`
 	Nodes      map[string]Node      `json:"nodes,omitempty"`
 	Net        []Connection         `json:"net,omitempty"`
-	Meta       core.Meta            `json:"meta,omitempty"`
+	Meta       core.Meta            `json:"meta"`
 }
 
 // Directive is an explicit instruction for compiler.
@@ -141,9 +142,9 @@ type Directive string
 
 // Interface describes abstract component.
 type Interface struct {
-	TypeParams TypeParams `json:"typeParams,omitempty"`
-	IO         IO         `json:"io,omitempty,"`
-	Meta       core.Meta  `json:"meta,omitempty"`
+	TypeParams TypeParams `json:"typeParams"`
+	IO         IO         `json:"io"`
+	Meta       core.Meta  `json:"meta"`
 }
 
 // TODO should we use it to typesystem package?
@@ -151,7 +152,7 @@ type Interface struct {
 //nolint:govet // fieldalignment: keep semantic grouping.
 type TypeParams struct {
 	Params []ts.Param `json:"params,omitempty"`
-	Meta   core.Meta  `json:"meta,omitempty"`
+	Meta   core.Meta  `json:"meta"`
 }
 
 func (t TypeParams) ToFrame() map[string]ts.Def {
@@ -166,25 +167,26 @@ func (t TypeParams) ToFrame() map[string]ts.Def {
 }
 
 func (t TypeParams) String() string {
-	s := "<"
+	var s strings.Builder
+	s.WriteString("<")
 	for i, param := range t.Params {
-		s += param.Name + " " + param.Constr.String()
+		s.WriteString(param.Name + " " + param.Constr.String())
 		if i < len(t.Params)-1 {
-			s += ", "
+			s.WriteString(", ")
 		}
 	}
-	return s + ">"
+	return s.String() + ">"
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Node struct {
 	Directives    map[Directive]string `json:"directives,omitempty"`
-	EntityRef     core.EntityRef       `json:"entityRef,omitempty"`
+	EntityRef     core.EntityRef       `json:"entityRef"`
 	TypeArgs      TypeArgs             `json:"typeArgs,omitempty"`
 	ErrGuard      bool                 `json:"errGuard,omitempty"`      // ErrGuard explains if node is used with `?` operator.
 	DIArgs        map[string]Node      `json:"diArgs,omitempty"`        // Dependency Injection.
 	OverloadIndex *int                 `json:"overloadIndex,omitempty"` // Only for overloaded components.
-	Meta          core.Meta            `json:"meta,omitempty"`
+	Meta          core.Meta            `json:"meta"`
 }
 
 const MissingNodeNamePrefix = "__missing_node_name__"
@@ -200,27 +202,28 @@ func (n Node) String() string {
 type TypeArgs []ts.Expr
 
 func (t TypeArgs) String() string {
-	s := "<"
+	var s strings.Builder
+	s.WriteString("<")
 	for i, arg := range t {
-		s += arg.String()
+		s.WriteString(arg.String())
 		if i < len(t)-1 {
-			s += " , "
+			s.WriteString(" , ")
 		}
 	}
-	return s + ">"
+	return s.String() + ">"
 }
 
 // Const represents abstraction that allow to define reusable message value.
 type Const struct {
-	TypeExpr ts.Expr    `json:"typeExpr,omitempty"`
-	Value    ConstValue `json:"value,omitempty"`
-	Meta     core.Meta  `json:"meta,omitempty"`
+	TypeExpr ts.Expr    `json:"typeExpr"`
+	Value    ConstValue `json:"value"`
+	Meta     core.Meta  `json:"meta"`
 }
 
 type ConstValue struct {
 	Ref     *core.EntityRef `json:"ref,omitempty"`
 	Message *MsgLiteral     `json:"message,omitempty"`
-	Meta    core.Meta       `json:"meta,omitempty"`
+	Meta    core.Meta       `json:"meta"`
 }
 
 func (c ConstValue) String() string {
@@ -239,14 +242,14 @@ type MsgLiteral struct {
 	List         []ConstValue          `json:"vec,omitempty"`
 	DictOrStruct map[string]ConstValue `json:"dict,omitempty"`
 	Union        *UnionLiteral         `json:"union,omitempty"`
-	Meta         core.Meta             `json:"meta,omitempty"`
+	Meta         core.Meta             `json:"meta"`
 }
 
 type UnionLiteral struct {
-	EntityRef core.EntityRef `json:"entityRef,omitempty"`
+	EntityRef core.EntityRef `json:"entityRef"`
 	Tag       string         `json:"tag,omitempty"`
 	Data      *ConstValue    `json:"data,omitempty"`
-	Meta      core.Meta      `json:"meta,omitempty"`
+	Meta      core.Meta      `json:"meta"`
 }
 
 func (m MsgLiteral) String() string {
@@ -260,20 +263,22 @@ func (m MsgLiteral) String() string {
 	case m.Str != nil:
 		return fmt.Sprintf("%q", *m.Str)
 	case len(m.List) != 0:
-		s := "["
+		var s strings.Builder
+		s.WriteString("[")
 		for i, item := range m.List {
-			s += item.String()
+			s.WriteString(item.String())
 			if i != len(m.List)-1 {
-				s += ", "
+				s.WriteString(", ")
 			}
 		}
-		return s + "]"
+		return s.String() + "]"
 	case len(m.DictOrStruct) != 0:
-		s := "{"
+		var s strings.Builder
+		s.WriteString("{")
 		for key, value := range m.DictOrStruct {
-			s += fmt.Sprintf("%q: %v", key, value.String())
+			fmt.Fprintf(&s, "%q: %v", key, value.String())
 		}
-		return s + "}"
+		return s.String() + "}"
 	}
 	return "message"
 }
@@ -281,27 +286,27 @@ func (m MsgLiteral) String() string {
 type IO struct {
 	In   map[string]Port `json:"in,omitempty"`
 	Out  map[string]Port `json:"out,omitempty"`
-	Meta core.Meta       `json:"meta,omitempty"`
+	Meta core.Meta       `json:"meta"`
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Port struct {
-	TypeExpr ts.Expr   `json:"typeExpr,omitempty"`
+	TypeExpr ts.Expr   `json:"typeExpr"`
 	IsArray  bool      `json:"isArray,omitempty"`
-	Meta     core.Meta `json:"meta,omitempty"`
+	Meta     core.Meta `json:"meta"`
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.
 type Connection struct {
 	Senders   []ConnectionSender   `json:"sender,omitempty"`
 	Receivers []ConnectionReceiver `json:"receiver,omitempty"`
-	Meta      core.Meta            `json:"meta,omitempty"`
+	Meta      core.Meta            `json:"meta"`
 }
 
 type ConnectionReceiver struct {
 	PortAddr          *PortAddr   `json:"portAddr,omitempty"`
 	ChainedConnection *Connection `json:"chainedConnection,omitempty"`
-	Meta              core.Meta   `json:"meta,omitempty"`
+	Meta              core.Meta   `json:"meta"`
 }
 
 //nolint:govet // fieldalignment: keep semantic grouping.
@@ -314,10 +319,10 @@ type ConnectionSender struct {
 }
 
 func (s ConnectionSender) String() string {
-	selectorsString := ""
+	var selectorsString strings.Builder
 	if len(s.StructSelector) != 0 {
 		for _, selector := range s.StructSelector {
-			selectorsString += "." + selector
+			selectorsString.WriteString("." + selector)
 		}
 	}
 
@@ -329,14 +334,14 @@ func (s ConnectionSender) String() string {
 		result = s.PortAddr.String()
 	}
 
-	return result + selectorsString
+	return result + selectorsString.String()
 }
 
 type PortAddr struct {
 	Node string    `json:"node,omitempty"`
 	Port string    `json:"port,omitempty"`
 	Idx  *uint8    `json:"idx,omitempty"` // TODO use bool flag instead of pointer to avoid problems with equality
-	Meta core.Meta `json:"meta,omitempty"`
+	Meta core.Meta `json:"meta"`
 }
 
 const ArrayBypassIdx uint8 = 255

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -12,7 +12,7 @@ import (
 type EntityRef struct {
 	Pkg  string `json:"pkg,omitempty"`
 	Name string `json:"name,omitempty"`
-	Meta Meta   `json:"meta,omitempty"`
+	Meta Meta   `json:"meta"`
 }
 
 func (e EntityRef) String() string {
@@ -27,15 +27,15 @@ func (e EntityRef) String() string {
 //nolint:govet // fieldalignment: keep order for readability and JSON grouping.
 type Meta struct {
 	Text  string   `json:"text,omitempty"`
-	Start Position `json:"start,omitempty"`
-	Stop  Position `json:"stop,omitempty"`
+	Start Position `json:"start"`
+	Stop  Position `json:"stop"`
 	// Location must always be present, even for virtual nodes inserted after resugaring,
 	// because irgen relies on it.
-	Location Location `json:"location,omitempty"`
+	Location Location `json:"location"`
 }
 
 type Location struct {
-	ModRef   ModuleRef `json:"module,omitempty"`
+	ModRef   ModuleRef `json:"module"`
 	Package  string    `json:"package,omitempty"`
 	Filename string    `json:"filename,omitempty"`
 }

--- a/pkg/golang/mod.go
+++ b/pkg/golang/mod.go
@@ -28,8 +28,8 @@ func FindModulePath(dst string) (string, error) {
 				scanner := bufio.NewScanner(f)
 				for scanner.Scan() {
 					line := scanner.Text()
-					if strings.HasPrefix(line, "module ") {
-						modName := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+					if after, ok := strings.CutPrefix(line, "module "); ok {
+						modName := strings.TrimSpace(after)
 						relPath, err := filepath.Rel(dir, absDst)
 						if err != nil {
 							return "", err


### PR DESCRIPTION
## Summary
- migrate repo toolchain to Go 1.26.0 (`go` + `toolchain` + GitHub Actions setup-go)
- add `make gofix` and `make gofix-check`
- run `go fix ./...` baseline rewrite and commit resulting modernizations
- add lint workflow step that fails when `go fix` would change files (`make gofix-check`)
- update AGENTS session notes with Go 1.26/gofix workflow learnings

## Validation
- `go fix ./...`
- `$HOME/go/bin/golangci-lint run ./...` (0 issues)
- `go test -count=1 -p 1 ./internal/... ./pkg/...` (pass)
- `go test -count=1 -p 1 ./e2e/for_with_range_and_if ./e2e/map_list_verbose` (pass)

## Notes
- Some long e2e/example packages hit local `-timeout=120s` when run in isolation (known heavy tests in this repo), so full `./...` was not completed in this run.
