### PR TITLE
chore: prepare v0.35.0 release baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,12 @@ Follow these instructions.
 - **Language semantics**: `maybe<T>` is represented as tagged union (`Some`/`None`) and union tags should use `CamelCase`.
 - **Architecture insights**: Recursion terminator must treat builtin `maybe` as recursive-wrapper to allow valid patterns like `error` chains (`... child maybe<error>`), even though `maybe` is no longer bodyless.
 - **Architecture insights**: Runtime trace concerns are now explicitly tracked as shared primitive (`#1050`) for panic diagnostics (`#595`), debugger (`#977`), and `std/errors` formatting (`#1046`); keep process semantics (`#792`) separate from diagnostics rendering.
+
+### Session Notes (2026-02-28, release workflow)
+
+- **Common patterns**: Minor language releases require bumping `pkg/version.go` (for example `0.34.0 -> 0.35.0`) and tagging with `v` prefix (`v0.35.0`).
+- **Common patterns**: Release artifacts come from `make build` and keep fixed names (`neva-{darwin,linux,windows}-{amd64,arm64}` plus `neva-linux-loong64`, `.exe` for Windows).
+- **Gotchas**: Local `golangci-lint` binaries can lag toolchain support (for example Go `1.26`); run via `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0` when needed.
 ## 3. ⚡ Core Concepts
 
 - **Dataflow**: Programs are graphs. Nodes process data; edges transport it.

--- a/internal/compiler/backend/golang/backend.go
+++ b/internal/compiler/backend/golang/backend.go
@@ -460,7 +460,8 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 	case ir.MsgTypeDict:
 		keyValuePairs := make([]string, 0, len(msg.DictOrStruct))
 		for k, v := range msg.DictOrStruct {
-			el, err := b.getMessageString(new(v))
+			value := v
+			el, err := b.getMessageString(&value)
 			if err != nil {
 				return "", err
 			}
@@ -470,7 +471,8 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 	case ir.MsgTypeStruct:
 		fields := make([]string, 0, len(msg.DictOrStruct))
 		for k, v := range msg.DictOrStruct {
-			el, err := b.getMessageString(new(v))
+			value := v
+			el, err := b.getMessageString(&value)
 			if err != nil {
 				return "", err
 			}

--- a/internal/compiler/desugarer/struct_selectors.go
+++ b/internal/compiler/desugarer/struct_selectors.go
@@ -88,9 +88,10 @@ func (Desugarer) createSelectorCfgMsg(senderSide src.ConnectionSender) src.Const
 	}
 
 	for _, selector := range senderSide.StructSelector {
+		selectorValue := selector
 		result = append(result, src.ConstValue{
 			Message: &src.MsgLiteral{
-				Str:  new(selector),
+				Str:  &selectorValue,
 				Meta: locOnlyMeta,
 			},
 		})

--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -838,10 +838,11 @@ func (s *treeShapeListener) parseMessage(
 				},
 			}
 		}
+		intVal := int(parsedInt)
 		if constVal.MINUS() != nil {
-			parsedInt = -parsedInt
+			intVal = -intVal
 		}
-		msg.Int = new(int(parsedInt))
+		msg.Int = &intVal
 	case constVal.FLOAT() != nil:
 		parsedFloat, err := strconv.ParseFloat(constVal.FLOAT().GetText(), 64)
 		if err != nil {
@@ -996,11 +997,11 @@ func (s *treeShapeListener) parseTypeDef(
 ) (src.Entity, *compiler.Error) {
 	var body *ts.Expr
 	if expr := actx.TypeExpr(); expr != nil {
-		v, err := s.parseTypeExpr(actx.TypeExpr())
+		typeExpr, err := s.parseTypeExpr(actx.TypeExpr())
 		if err != nil {
 			return src.Entity{}, err
 		}
-		body = new(v)
+		body = &typeExpr
 	}
 
 	v, err := s.parseTypeParams(actx.TypeParams())

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -2,4 +2,4 @@ package pkg
 
 // Version is the current version of the language and stdlib.
 // Don't forget to update it before release new tag.
-var Version = "0.34.0" //nolint:gochecknoglobals
+var Version = "0.35.0" //nolint:gochecknoglobals


### PR DESCRIPTION
## Summary\n- bump language version to 0.35.0\n- fix current golangci-lint findings on main (staticcheck/wastedassign)\n- update AGENTS session notes\n\n## Validation\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./...\n- go test ./cmd/... ./internal/... ./pkg/...\n- make build