### PR TITLE
backend/golang: centralize release build args and reproducible flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,11 @@ Follow these instructions.
 - **Common patterns**: For mass `fieldalignment` cleanup, remove stale `//nolint:govet` first, then run `fieldalignment -fix` iteratively until diagnostics converge.
 - **Gotchas**: `betteralign` may not fully satisfy `govet` `fieldalignment`; prefer `golang.org/x/tools/.../fieldalignment` for authoritative fixes.
 - **Common patterns**: If `staticcheck` flags loop `break` patterns (`QF1006`), lift the condition into the `for` header instead of suppressing with `nolint`.
+
+### Session Notes (2026-03-08)
+
+- **Common patterns**: Keep build-flags/reproducibility updates in a focused PR; move cross-layer compiler/runtime optimization experiments into dedicated follow-up issues.
+- **Architecture insights**: Runtime funcs minimization via `IR ref -> registry entry -> Go file deps` can shrink binaries, but should be tracked as separate design work to avoid high-review-complexity backend diffs.
 ## 3. ⚡ Core Concepts
 
 - **Dataflow**: Programs are graphs. Nodes process data; edges transport it.

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ nilaway:
 
 # === Release Build ===
 
+# Release flags:
+# -trimpath removes host paths from debug metadata (smaller, reproducible artifacts)
+# -buildvcs=false skips VCS stamping to keep output deterministic and compact
 # build neva cli for all target platforms
 .PHONY: build
 build:
@@ -50,34 +53,34 @@ build:
 # build neva cli for amd64 mac
 .PHONY: build-darwin-amd64
 build-darwin-amd64:
-	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o neva-darwin-amd64 ./cmd/neva
+	@GOOS=darwin GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-darwin-amd64 ./cmd/neva
 
 # build neva cli for arm64 mac
 .PHONY: build-darwin-arm64
 build-darwin-arm64:
-	@GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o neva-darwin-arm64 ./cmd/neva
+	@GOOS=darwin GOARCH=arm64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-darwin-arm64 ./cmd/neva
 
 # build neva cli for amd64 linux
 .PHONY: build-linux-amd64
 build-linux-amd64:
-	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o neva-linux-amd64 ./cmd/neva
+	@GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-linux-amd64 ./cmd/neva
 
 # build neva cli for arm64 linux
 .PHONY: build-linux-arm64
 build-linux-arm64:
-	@GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o neva-linux-arm64 ./cmd/neva
+	@GOOS=linux GOARCH=arm64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-linux-arm64 ./cmd/neva
 
 # build neva cli for loong64 linux
 .PHONY: build-linux-loong64
 build-linux-loong64:
-	@GOOS=linux GOARCH=loong64 go build -ldflags="-s -w" -o neva-linux-loong64 ./cmd/neva
+	@GOOS=linux GOARCH=loong64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-linux-loong64 ./cmd/neva
 
 # build neva cli for amd64 windows
 .PHONY: build-windows-amd64
 build-windows-amd64:
-	@GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o neva-windows-amd64.exe ./cmd/neva
+	@GOOS=windows GOARCH=amd64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-windows-amd64.exe ./cmd/neva
 
 # build neva cli for arm64 windows
 .PHONY: build-windows-arm64
 build-windows-arm64:
-	@GOOS=windows GOARCH=arm64 go build -ldflags="-s -w" -o neva-windows-arm64.exe ./cmd/neva
+	@GOOS=windows GOARCH=arm64 go build -trimpath -buildvcs=false -ldflags="-s -w" -o neva-windows-arm64.exe ./cmd/neva

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/nevalang/neva/internal/builder"
 	"github.com/nevalang/neva/internal/compiler"
-	"github.com/nevalang/neva/internal/compiler/backend/golang"
+	backendgolang "github.com/nevalang/neva/internal/compiler/backend/golang"
 	"github.com/nevalang/neva/internal/compiler/desugarer"
+	"github.com/nevalang/neva/pkg/golang"
 )
 
 func newInstallCmd(
@@ -82,7 +83,7 @@ func newInstallCmd(
 				&desugarer,
 				analyzer,
 				irgen,
-				golang.NewBackend("", false),
+				backendgolang.NewBackend("", false),
 			)
 
 			if _, err := compilerToGo.Compile(cliCtx.Context, compiler.CompilerInput{
@@ -128,7 +129,10 @@ func newInstallCmd(
 				}
 			}()
 
-			cmd := exec.Command("go", "build", "-ldflags", "-s -w", "-o", targetPath, ".")
+			// Keep build flags centralized so CLI/install and compiler backends stay in sync.
+			// This avoids silent drift in artifact reproducibility/size behavior over time.
+			// #nosec G204 -- command args are constructed internally from known values
+			cmd := exec.Command("go", golang.ReleaseBuildArgs(targetPath, ".")...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 

--- a/internal/compiler/backend/golang/native/backend.go
+++ b/internal/compiler/backend/golang/native/backend.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 
 	"github.com/nevalang/neva/internal/compiler"
-	"github.com/nevalang/neva/internal/compiler/backend/golang"
+	backendgolang "github.com/nevalang/neva/internal/compiler/backend/golang"
 	"github.com/nevalang/neva/internal/compiler/ir"
+	"github.com/nevalang/neva/pkg/golang"
 )
 
 type Backend struct {
-	golang golang.Backend
+	golang backendgolang.Backend
 }
 
 func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error {
@@ -49,11 +50,7 @@ func (b Backend) buildExecutable(gomodule, output string) error {
 	// #nosec G204 -- command args are constructed internally from known values
 	cmd := exec.Command(
 		"go",
-		"build",
-		"-ldflags", "-s -w", // strip debug information
-		"-o",
-		filepath.Join(output, fileName),
-		".",
+		golang.ReleaseBuildArgs(filepath.Join(output, fileName), ".")...,
 	)
 	cmd.Dir = gomodule
 	cmd.Stdout = os.Stdout
@@ -62,7 +59,7 @@ func (b Backend) buildExecutable(gomodule, output string) error {
 	return cmd.Run()
 }
 
-func NewBackend(golangBackend golang.Backend) Backend {
+func NewBackend(golangBackend backendgolang.Backend) Backend {
 	return Backend{
 		golang: golangBackend,
 	}

--- a/internal/compiler/backend/golang/wasm/backend.go
+++ b/internal/compiler/backend/golang/wasm/backend.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 
 	"github.com/nevalang/neva/internal/compiler"
-	"github.com/nevalang/neva/internal/compiler/backend/golang"
+	backendgolang "github.com/nevalang/neva/internal/compiler/backend/golang"
 	"github.com/nevalang/neva/internal/compiler/ir"
+	"github.com/nevalang/neva/pkg/golang"
 )
 
 type Backend struct {
-	golang golang.Backend
+	golang backendgolang.Backend
 }
 
 func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error {
@@ -38,10 +39,7 @@ func buildWASM(src, dst string) error {
 	// #nosec G204 -- command args are constructed internally from known values
 	cmd := exec.Command(
 		"go",
-		"build",
-		"-ldflags", "-s -w", // for optimization
-		"-o", outputPath+".wasm",
-		src,
+		golang.ReleaseBuildArgs(outputPath+".wasm", src)...,
 	)
 	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	cmd.Stdout = os.Stdout
@@ -49,7 +47,7 @@ func buildWASM(src, dst string) error {
 	return cmd.Run()
 }
 
-func NewBackend(golangBackend golang.Backend) Backend {
+func NewBackend(golangBackend backendgolang.Backend) Backend {
 	return Backend{
 		golang: golangBackend,
 	}

--- a/pkg/golang/build_args.go
+++ b/pkg/golang/build_args.go
@@ -1,0 +1,17 @@
+package golang
+
+// ReleaseBuildArgs returns standardized `go build` args for end-user artifacts.
+// Flags are intentionally centralized to avoid drift across CLI/backends and
+// to keep binaries compact and reproducible by default.
+func ReleaseBuildArgs(outputPath, target string) []string {
+	return []string{
+		"build",
+		"-trimpath",       // remove host-specific paths from debug metadata
+		"-buildvcs=false", // do not embed VCS metadata into produced artifacts
+		"-ldflags",
+		"-s -w", // strip debug/symbol data to reduce binary size
+		"-o",
+		outputPath,
+		target,
+	}
+}


### PR DESCRIPTION
## Summary

This PR is intentionally scoped down to low-risk build-output improvements.

Included:

1. Centralized reusable release `go build` args in `pkg/golang`.
2. Applied deterministic/compact build flags for end-user artifacts:
   - `-trimpath`
   - `-buildvcs=false`

## What changed

- Added `pkg/golang.ReleaseBuildArgs(...)` and reused it in:
  - `internal/cli/install.go`
  - `internal/compiler/backend/golang/native/backend.go`
  - `internal/compiler/backend/golang/wasm/backend.go`
- Kept/used inline comments explaining why these flags are enabled.
- Kept release Makefile targets aligned with the same flag intent.
- Normalized `pkg/golang` imports to use package name directly (no `pkggolang` alias).

## Explicitly removed from this PR

The prototype for executable runtime funcs minimization (AST-based file selection + generated minimal registry) was removed to keep this PR reviewable and low-complexity.

Follow-up tracking issue: #1059.

## Validation

- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./... --timeout 5m`
- `go test ./... -timeout 5m`
