### PR TITLE
docs(cache): document stdlib fingerprinting constraints and close issue tails

### DIFF
--- a/internal/builder/std.go
+++ b/internal/builder/std.go
@@ -20,7 +20,9 @@ func ensureStdlib() (string, error) {
 
 	path := filepath.Join(home, "neva", "std")
 
-	// Compute checksum of the embedded stdlib
+	// Keep stdlib invalidation content-based: embed.FS file metadata does not carry
+	// reliable mtimes (ModTime is zero), so metadata-only fingerprinting can miss
+	// same-size content edits.
 	embeddedChecksum, err := nevaos.ComputeChecksumForFS(std.FS)
 	if err != nil {
 		return "", fmt.Errorf("compute embedded checksum: %w", err)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -333,6 +333,8 @@ func e2eCacheRootDir() (string, error) {
 
 // nevaBuildFingerprint computes a stable cache key from local build input metadata:
 // relative path + size + mtime(ns) for each selected file.
+// This path is for on-disk repo files only; stdlib extraction uses content hashing
+// because embed.FS metadata does not provide reliable mtimes.
 func nevaBuildFingerprint(repoRoot string) (string, error) {
 	files, err := compilerInputFiles(repoRoot)
 	if err != nil {

--- a/pkg/os/checksum.go
+++ b/pkg/os/checksum.go
@@ -9,7 +9,9 @@ import (
 	"sort"
 )
 
-// ComputeChecksum computes a checksum of all files in the embedded FS
+// ComputeChecksumForFS hashes full file contents for deterministic FS invalidation.
+// This is intentionally stronger than metadata-only keys, which are not reliable
+// for embed.FS (file mtime is zero/unknown).
 func ComputeChecksumForFS(filesys fs.FS) (string, error) {
 	// First pass: collect all files
 	var filenames []string


### PR DESCRIPTION
## Summary
- add explicit code comments documenting why stdlib cache invalidation stays content-based
- clarify in e2e fingerprint helper that metadata-based strategy is for on-disk repo files only
- align issue tails:
  - close #1063 with rationale (single-strategy unification not planned)
  - keep parallelism follow-up in #1064 and cross-link umbrella issue #1008

## Why
`embed.FS` does not provide reliable mtime entropy, so metadata-only invalidation is not equivalent for stdlib extraction. The comments make this constraint explicit in code to avoid future confusion.

## Validation
- `golangci-lint run ./internal/builder ./pkg/os ./pkg/e2e`
- `go test ./internal/builder/... ./pkg/os ./pkg/e2e`
