### PR TITLE
ci(test): run e2e/examples with default Go package parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
       with:
         go-version: '1.26.1'
     - name: test (e2e and examples)
-      # Start conservatively with package parallelism while issue #767 is being retired.
-      run: go test -v -p 2 ./e2e/... ./examples/...
+      # Run with default Go package parallelism; isolation hardening is tracked in #1064.
+      run: go test -v ./e2e/... ./examples/...


### PR DESCRIPTION
## Summary
- remove explicit `-p 2` from e2e/examples CI lane
- rely on default Go package parallelism in test workflow
- keep issue reference in workflow comment (`#1064`) for ongoing isolation hardening

## Why
This moves us to the desired default Go concurrency model and continues the rollout from the previous conservative cap.

## Validation
Local smoke checks passed:
- `go test -v ./e2e/99_bottles_verbose ./e2e/simple_fan_out`
- `go test -v ./examples/select ./examples/filter_list`
