### PR TITLE
docs: add modern Go guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,14 +68,11 @@ high-signal constraints:
 
 - Source of truth: `.golangci.yml`, `go.mod`, and existing code patterns.
 - Treat `go.mod` as the version ceiling for Go features and stdlib APIs.
-  This repository currently targets Go 1.26.
 - Prefer modern Go idioms available in the target version over legacy
   patterns. By default, favor `any`, `errors.AsType[T]`, `new(val)`,
   `wg.Go`, `b.Loop`, `t.Context()`, `slices`/`maps`/`cmp`, `min`/`max`,
   `SplitSeq`/`FieldsSeq` for iteration-only use, and `omitzero` when
   zero-value JSON semantics matter.
-- Do not use newer Go features than the repo target, and do not perform
-  mechanical modernizations that reduce clarity.
 - Always run `gofmt` on changed Go files.
 - Respect active lints (notable strict checks include `depguard`,
   `fieldalignment`, `nil*`, `gosec`, `gochecknoglobals`, `gochecknoinits`).


### PR DESCRIPTION
## Summary
- add a version-aware modern Go policy to `AGENTS.md`
- state that this repo targets Go 1.26 and agents should use supported modern idioms
- list the small set of modern defaults we want agents to prefer without turning the file into a style catalog

## Testing
- not run (documentation-only change)