### PR TITLE
benchmarks: add atomic one-shot builtin batch

### DIFF
--- a/benchmarks/atomic/builtin_lock/main.neva
+++ b/benchmarks/atomic/builtin_lock/main.neva
@@ -1,9 +1,6 @@
 def Main(start any) (stop any) {
-	lock Lock<int>
+	lock Lock<any>
 	---
-	:start -> [
-		lock:sig,
-		1 -> lock:data
-	]
+	:start -> [lock:sig, lock:data]
 	lock -> :stop
 }

--- a/benchmarks/atomic/builtin_pass/main.neva
+++ b/benchmarks/atomic/builtin_pass/main.neva
@@ -1,5 +1,5 @@
 def Main(start any) (stop any) {
-	pass Pass<int>
+	pass Pass<any>
 	---
-	:start -> 1 -> pass -> :stop
+	:start -> pass -> :stop
 }


### PR DESCRIPTION
## Summary
This PR is the next slice after #1073 and adds the first truly atomic builtin runtime benchmarks.

## Included
- `benchmarks/atomic/builtin_pass`
- `benchmarks/atomic/builtin_lock`

Both benchmarks use a single `:start` event and keep the measured builtin on the hot path without `streams.Range`, `streams.Wait`, or `sync.WaitGroup` in the measured flow.

## Notes
- The previous `fan_in` and `fan_out` drafts were intentionally removed from this PR.
- Those components need additional support wiring to produce a valid standalone benchmark, and that methodology should be reviewed separately instead of being mixed into the first atomic batch.

## Validation
- `go test ./benchmarks -run=^$ -bench BenchmarkRuntimeE2E -benchtime=1x -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./benchmarks`
