### PR TITLE
docs: record stdlib coverage policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,9 @@ make gofix
   `docs/style_guide.md` and `docs/qna.md`.
 - If compiler bootstrap utils are affected, regenerate from repo CLI
   (avoid stale global binaries).
+- Treat per-component e2e and benchmark coverage as the long-term stdlib
+  maintenance goal. Start with atomic benchmarks and add broader scenarios
+  only when they are justified by a distinct behavior or performance question.
 
 ### Tests and e2e
 


### PR DESCRIPTION
## Summary
- record the long-term stdlib coverage goal in root `AGENTS.md`
- state that per-component `e2e` and benchmark coverage is the target
- clarify that coverage should start with atomic benchmarks and widen only when justified

## Testing
- not run (docs-only change)
