### PR TITLE
benchmarks: add atomic scalar-cast builtin benchmarks

### DIFF
--- a/benchmarks/atomic/builtin_float/main.neva
+++ b/benchmarks/atomic/builtin_float/main.neva
@@ -1,0 +1,6 @@
+// Benchmarks builtin component `Float` in one-shot mode.
+def Main(start any) (stop any) {
+	to_float Float
+	---
+	:start -> 42 -> to_float -> :stop
+}

--- a/benchmarks/atomic/builtin_int/main.neva
+++ b/benchmarks/atomic/builtin_int/main.neva
@@ -1,0 +1,6 @@
+// Benchmarks builtin component `Int` in one-shot mode.
+def Main(start any) (stop any) {
+	to_int Int
+	---
+	:start -> 1.9 -> to_int -> :stop
+}

--- a/benchmarks/atomic/builtin_string/main.neva
+++ b/benchmarks/atomic/builtin_string/main.neva
@@ -1,0 +1,6 @@
+// Benchmarks builtin component `String` in one-shot mode.
+def Main(start any) (stop any) {
+	to_string String
+	---
+	:start -> 65 -> to_string -> :stop
+}


### PR DESCRIPTION
## Summary
- add atomic one-shot benchmark for `Int`
- add atomic one-shot benchmark for `Float`
- add atomic one-shot benchmark for `String`

## Validation
- `go test ./benchmarks -run=^$ -bench 'BenchmarkRuntimeE2E/atomic_' -benchtime=1x -count=1`
- `go test ./benchmarks -run=^$ -bench 'BenchmarkRuntimeE2E/atomic_builtin_(float|int|string)$' -benchtime=1x -count=1`
