### PR TITLE
benchmarks: add atomic builtin else/error and gate batch

### DIFF
--- a/benchmarks/atomic/builtin_cond_else/main.neva
+++ b/benchmarks/atomic/builtin_cond_else/main.neva
@@ -1,0 +1,10 @@
+// Benchmarks builtin component `Cond` else-path in one-shot mode.
+def Main(start any) (stop any) {
+	cond Cond<int>
+	---
+	:start -> [
+		42 -> cond:data,
+		false -> cond:if
+	]
+	cond:else -> :stop
+}

--- a/benchmarks/atomic/builtin_del/main.neva
+++ b/benchmarks/atomic/builtin_del/main.neva
@@ -1,0 +1,9 @@
+// Benchmarks builtin component `Del` in one-shot mode.
+def Main(start any) (stop any) {
+	del Del
+	---
+	:start -> [
+		1 -> del,
+		:stop
+	]
+}

--- a/benchmarks/atomic/builtin_gate/main.neva
+++ b/benchmarks/atomic/builtin_gate/main.neva
@@ -1,0 +1,10 @@
+// Benchmarks builtin component `Gate` in one-shot mode.
+def Main(start any) (stop any) {
+	gate Gate<int>
+	---
+	:start -> [
+		42 -> gate:data,
+		true -> gate:if
+	]
+	gate -> :stop
+}

--- a/benchmarks/atomic/builtin_gate_false_then_true/main.neva
+++ b/benchmarks/atomic/builtin_gate_false_then_true/main.neva
@@ -1,0 +1,13 @@
+// Benchmarks builtin component `Gate` with ignored false signal first.
+def Main(start any) (stop any) {
+	gate Gate<int>
+	signals FanIn<bool>
+	---
+	:start -> [
+		42 -> gate:data,
+		false -> signals:data[0],
+		true -> signals:data[1]
+	]
+	signals -> gate:if
+	gate -> :stop
+}

--- a/benchmarks/atomic/builtin_get_err/main.neva
+++ b/benchmarks/atomic/builtin_get_err/main.neva
@@ -1,0 +1,16 @@
+// Benchmarks builtin component `Get` error-path in one-shot mode.
+const value dict<string> = {
+	answer: '42'
+}
+
+def Main(start any) (stop any) {
+	dict_key Get<string>
+	del Del
+	---
+	:start -> [
+		$value -> dict_key:dict,
+		'missing' -> dict_key:key
+	]
+	dict_key:res -> del
+	dict_key:err -> :stop
+}

--- a/benchmarks/atomic/builtin_if/main.neva
+++ b/benchmarks/atomic/builtin_if/main.neva
@@ -1,0 +1,7 @@
+// Benchmarks builtin component `If` in one-shot mode.
+def Main(start any) (stop any) {
+	if_router If<any>
+	---
+	:start -> true -> if_router:data
+	if_router:then -> :stop
+}

--- a/benchmarks/atomic/builtin_if_else/main.neva
+++ b/benchmarks/atomic/builtin_if_else/main.neva
@@ -1,0 +1,7 @@
+// Benchmarks builtin component `If` else-path in one-shot mode.
+def Main(start any) (stop any) {
+	if_router If<any>
+	---
+	:start -> false -> if_router:data
+	if_router:else -> :stop
+}

--- a/benchmarks/atomic/builtin_match_else/main.neva
+++ b/benchmarks/atomic/builtin_match_else/main.neva
@@ -1,0 +1,12 @@
+// Benchmarks builtin component `Match` else-path in one-shot mode.
+def Main(start any) (stop any) {
+	match Match<int>
+	---
+	:start -> [
+		3 -> match:data,
+		1 -> match:if[0],
+		42 -> match:then[0],
+		0 -> match:else
+	]
+	match -> :stop
+}

--- a/benchmarks/atomic/builtin_switch_else/main.neva
+++ b/benchmarks/atomic/builtin_switch_else/main.neva
@@ -1,0 +1,12 @@
+// Benchmarks builtin component `Switch` else-path in one-shot mode.
+def Main(start any) (stop any) {
+	switch_router Switch<int>
+	del Del
+	---
+	:start -> [
+		3 -> switch_router:data,
+		1 -> switch_router:case[0]
+	]
+	switch_router:case[0] -> del
+	switch_router:else -> :stop
+}

--- a/benchmarks/atomic/builtin_ternary_else/main.neva
+++ b/benchmarks/atomic/builtin_ternary_else/main.neva
@@ -1,0 +1,11 @@
+// Benchmarks builtin component `Ternary` else-path in one-shot mode.
+def Main(start any) (stop any) {
+	ternary Ternary<int>
+	---
+	:start -> [
+		false -> ternary:if,
+		42 -> ternary:then,
+		0 -> ternary:else
+	]
+	ternary -> :stop
+}


### PR DESCRIPTION
## Summary
- add atomic benchmark for missing builtin components `If`, `Gate`, `Del`
- add explicit context benchmarks for else/error paths:
  - `builtin_cond_else`
  - `builtin_ternary_else`
  - `builtin_match_else`
  - `builtin_switch_else`
  - `builtin_get_err`
- add `builtin_if_else` and `builtin_gate_false_then_true` to cover non-default branch behavior

## Validation
- `go test ./benchmarks -run=^$ -bench 'BenchmarkRuntimeE2E/atomic_builtin_(if|if_else|gate|gate_false_then_true|del|cond_else|ternary_else|match_else|switch_else|get_err)$' -benchtime=1x -count=1`
- `go test ./benchmarks -run=^$ -bench 'BenchmarkRuntimeE2E/atomic_' -benchtime=1x -count=1`
