### PR TITLE
examples: fix delayed echo wait group count

### DIFF
--- a/examples/delayed_echo/main.neva
+++ b/examples/delayed_echo/main.neva
@@ -23,7 +23,7 @@ def Main(start any) (stop any) {
 		4 -> w4,
 		5 -> w5,
 		'World' -> w6,
-		6 -> wg:count
+		7 -> wg:count
 	]
 	[w1, w2, w3, w4, w5, w6, println] -> wg:sig
 	wg -> :stop


### PR DESCRIPTION
## Summary
- fix `examples/delayed_echo` wait-group accounting so `:stop` does not fire before the last delayed print
- keep the scenario and assertions unchanged; only align `wg:count` with the actual number of `wg:sig` senders

## Why
`examples/delayed_echo` was the current failing package in `#1023` CI (`e2e_tests`), but the failure is independent from the benchmark work itself.

The program wires `wg:sig` from 7 producers (`w1..w6` plus `println`) while setting `wg:count` to `6`, which allows premature termination and intermittent loss of the last line.

## Validation
- `go test ./examples/delayed_echo -count=20`
