### PR TITLE
chore(lint): remove strict-phase TODO tails from nolint comments

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkRuntimeE2E(b *testing.B) {
 
 // discoverBenchmarkPkgs finds all benchmark packages under benchmark tiers.
 //
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func discoverBenchmarkPkgs(repoRoot string) ([]string, error) {
 	benchmarksRoot := filepath.Join(repoRoot, "benchmarks")
 	pkgs := make([]string, 0, 64)
@@ -73,7 +73,7 @@ func discoverBenchmarkPkgs(repoRoot string) ([]string, error) {
 			return nil
 		})
 		if walkErr != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return nil, walkErr
 		}
 	}
@@ -114,7 +114,7 @@ func buildProgramOnce(b *testing.B, repoRoot, nevaBin, pkgName string) string {
 	}
 
 	// Compile the benchmark program once and return its output binary.
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	buildProg := exec.Command(nevaBin, "build", pkgName)
 	buildProg.Dir = moduleDir
 	buildProg.Env = append(os.Environ(), "HOME="+homeDir)

--- a/e2e/cli/build_with_go_pkg_mode/e2e_test.go
+++ b/e2e/cli/build_with_go_pkg_mode/e2e_test.go
@@ -47,7 +47,7 @@ pub def PrintHello(sig int) (res string) {
 
 	// go mod init in "gen" dir BEFORE build to let compiler detect module path
 	require.NoError(t, os.Mkdir("gen", 0o755))
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	goModInit := exec.Command("go", "mod", "init", "example.com/tmpgen")
 	goModInit.Dir = "gen"
 	out, err := goModInit.CombinedOutput()
@@ -78,7 +78,7 @@ func main(){
 	require.NoError(t, os.WriteFile(filepath.Join("gen", "main.go"), []byte(runner), 0o644))
 
 	// Just go run .
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	run := exec.Command("go", "run", ".")
 	run.Dir = "gen"
 	out, err = run.CombinedOutput()

--- a/e2e/cli/debug_runtime_validation/e2e_test.go
+++ b/e2e/cli/debug_runtime_validation/e2e_test.go
@@ -40,7 +40,7 @@ func TestDebugRuntimeValidation(t *testing.T) {
 	require.Contains(t, string(debugBytes), "func DebugValidation")
 
 	// Build the generated Go module to ensure the code compiles.
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	buildCmd := exec.Command("go", "build", "-o", "app", ".")
 	buildCmd.Dir = "gen"
 	buildOut, err := buildCmd.CombinedOutput()
@@ -52,7 +52,7 @@ func TestDebugRuntimeValidation(t *testing.T) {
 		binaryPath += ".exe"
 	}
 
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	runCmd := exec.Command(binaryPath)
 	runOut, err := runCmd.CombinedOutput()
 	require.NoError(t, err, string(runOut))

--- a/e2e/cli/install/e2e_test.go
+++ b/e2e/cli/install/e2e_test.go
@@ -73,7 +73,7 @@ func TestInstall(t *testing.T) {
 	require.Equal(t, installedBinary, foundPath, "LookPath should return the installed binary path")
 
 	// Run the binary using just the command name (without full path)
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	runCmd := exec.Command(expectedBinName)
 	runCmd.Dir = workdir
 	runOut, runErr := runCmd.CombinedOutput()

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -71,7 +71,7 @@ func (b Builder) Build(
 	}
 	defer release()
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	q := newQueue(entryMod.Manifest.Deps)
 
 	for !q.empty() {
@@ -115,7 +115,7 @@ func (b Builder) Build(
 func getThirdPartyPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", err
 	}
 
@@ -123,7 +123,7 @@ func getThirdPartyPath() (string, error) {
 
 	err = os.MkdirAll(path, os.ModePerm)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", err
 	}
 

--- a/internal/builder/get.go
+++ b/internal/builder/get.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nevalang/neva/pkg/core"
 )
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (b Builder) Get(wd, path, version string) (string, error) {
 	ref := core.ModuleRef{
 		Path:    path,

--- a/internal/builder/git.go
+++ b/internal/builder/git.go
@@ -45,7 +45,7 @@ func (p Builder) downloadDep(depModRef core.ModuleRef) (string, string, error) {
 		ReferenceName: ref,
 	})
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", "", err
 	}
 
@@ -59,7 +59,7 @@ func (p Builder) downloadDep(depModRef core.ModuleRef) (string, string, error) {
 	}
 
 	if err := nevaGit.Checkout(repo, latestTagHash.String()); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", "", err
 	}
 
@@ -84,7 +84,7 @@ func (p Builder) downloadDep(depModRef core.ModuleRef) (string, string, error) {
 func getLatestTagHash(repository *gitlib.Repository) (plumbing.Hash, string, error) {
 	tagRefs, err := repository.Tags()
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return plumbing.Hash{}, "", err
 	}
 
@@ -98,7 +98,7 @@ func getLatestTagHash(repository *gitlib.Repository) (plumbing.Hash, string, err
 		return nil
 	})
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return plumbing.Hash{}, "", err
 	}
 

--- a/internal/builder/lock.go
+++ b/internal/builder/lock.go
@@ -19,18 +19,18 @@ import (
 // The lock is necessary because multiple concurrent builds could try to download and write
 // the same dependency files simultaneously, which could corrupt the dependency cache.
 //
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func acquireLockFile() (release func(), err error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	filename := filepath.Join(home, "neva", ".lock")
 
 	for range 60 {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		f, err := os.OpenFile(
 			filename,
 			os.O_CREATE|os.O_EXCL,

--- a/internal/builder/manifest.go
+++ b/internal/builder/manifest.go
@@ -26,7 +26,7 @@ func (p Builder) getNearestManifest(wd string) (ast.ModuleManifest, string, erro
 	return parsedNearest, path, nil
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func lookupManifestFile(wd string, iteration int) ([]byte, string, error) {
 	if iteration > 10 {
 		return nil, "", errors.New("manifest file not found in 10 nearest levels up to where cli executed")
@@ -48,13 +48,13 @@ func lookupManifestFile(wd string, iteration int) ([]byte, string, error) {
 	)
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func readManifestFromDir(wd string) ([]byte, error) {
 	raw, err := os.ReadFile(filepath.Join(wd, "neva.yaml"))
 	if err == nil {
 		return raw, nil
 	}
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return os.ReadFile(filepath.Join(wd, "neva.yml"))
 }
 

--- a/internal/builder/mod.go
+++ b/internal/builder/mod.go
@@ -35,7 +35,7 @@ func (p Builder) LoadModuleByPath(
 // retrieveSourceCode recursively walks the given tree and fills given pkgs with neva files
 func retrieveSourceCode(rootPath string, pkgs map[string]compiler.RawPackage) error {
 	fsys := os.DirFS(rootPath)
-	//nolint:varnamelen,wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen,wrapcheck
 	return fs.WalkDir(fsys, ".", func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("filepath walk: %s: %w", filePath, err)
@@ -52,15 +52,15 @@ func retrieveSourceCode(rootPath string, pkgs map[string]compiler.RawPackage) er
 
 		file, err := fsys.Open(filePath)
 		if err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 		defer file.Close()
 
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		bb, err := io.ReadAll(file)
 		if err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 

--- a/internal/builder/std.go
+++ b/internal/builder/std.go
@@ -13,7 +13,7 @@ import (
 
 // ensureStdlib ensures the standard library is properly extracted and up-to-date
 //
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func ensureStdlib() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -53,7 +53,7 @@ func ensureStdlib() (string, error) {
 	}
 
 	// Write all files from the embedded FS
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	err = fs.WalkDir(std.FS, ".", func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("walk error at %s: %w", filePath, err)
@@ -108,6 +108,6 @@ func readChecksum(stdlibPath string) (string, error) {
 func writeChecksum(stdlibPath, checksum string) error {
 	checksumPath := filepath.Join(stdlibPath, ".checksum")
 	// #nosec G306 -- checksum is a non-sensitive build artifact
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return os.WriteFile(checksumPath, []byte(checksum), 0644)
 }

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -22,8 +22,8 @@ import (
 )
 
 //nolint:gocyclo // CLI flag setup is dense; refactor later without behavior changes.
-//nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func newBuildCmd( //nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx
+func newBuildCmd( //nolint:cyclop,funlen,gocognit,maintidx
 	workdir string,
 	bldr builder.Builder,
 	parser parser.Parser,
@@ -92,18 +92,18 @@ func newBuildCmd( //nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint p
 
 			targetOS := cliCtx.String("target-os")
 			if targetOS != "" && target != "native" {
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Errorf("target-os and target-arch are only supported when target is native")
 			}
 
 			targetArch := cliCtx.String("target-arch")
 			if targetArch != "" && target != "native" {
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Errorf("target-arch is only supported when target is native")
 			}
 
 			if (targetOS != "" && targetArch == "") || (targetOS == "" && targetArch != "") {
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Errorf("target-os and target-arch must be set together")
 			}
 

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -14,7 +14,7 @@ import (
 	"github.com/nevalang/neva/std"
 )
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func newDocCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "doc",
@@ -116,7 +116,7 @@ func normalizePkgArg(arg string) string {
 	return strings.ReplaceAll(trimmed, "\\", "/")
 }
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func searchStdlib(pkgPath string, re *regexp.Regexp, context int) ([]docMatch, error) {
 	if context < 0 {
 		context = 0
@@ -148,12 +148,12 @@ func searchStdlib(pkgPath string, re *regexp.Regexp, context int) ([]docMatch, e
 
 		data, err := fs.ReadFile(fsys, entryPath)
 		if err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 
 		lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for i, line := range lines {
 			if !re.MatchString(line) {
 				continue
@@ -188,7 +188,7 @@ func searchStdlib(pkgPath string, re *regexp.Regexp, context int) ([]docMatch, e
 		return nil
 	})
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -16,7 +16,7 @@ import (
 	"github.com/nevalang/neva/pkg/golang"
 )
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func newInstallCmd(
 	workdir string,
 	bldr builder.Builder,
@@ -93,7 +93,7 @@ func newInstallCmd(
 				EmitTraceFile: false,
 				Mode:          compiler.ModeExecutable,
 			}); err != nil {
-				//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:wrapcheck
 				return err
 			}
 
@@ -116,7 +116,7 @@ func newInstallCmd(
 
 			// Use go build to build directly to the target location
 			// This leverages Go's build system while giving us control over binary name
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			wd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
@@ -135,7 +135,7 @@ func newInstallCmd(
 			// Keep build flags centralized so CLI/install and compiler backends stay in sync.
 			// This avoids silent drift in artifact reproducibility/size behavior over time.
 			// #nosec G204 -- command args are constructed internally from known values
-			//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:noctx
 			cmd := exec.Command("go", golang.ReleaseBuildArgs(targetPath, ".")...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -213,7 +213,7 @@ func resolveMainPkgPath(absPkg string) (string, error) {
 func dirContainsNeva(path string) (bool, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return false, err
 	}
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -36,14 +36,14 @@ func newNewCmd() *cli.Command {
 
 			template := cCtx.String("template")
 
-			//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:nestif
 			if template != "" {
 				if err := scaffoldFromTemplate(pathArg, template); err != nil {
 					return err
 				}
 			} else {
 				if err := os.MkdirAll(pathArg, 0o755); err != nil {
-					//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:wrapcheck
 					return err
 				}
 				if err := createNevaMod(pathArg); err != nil {
@@ -80,20 +80,20 @@ func createNevaMod(path string) error {
 		fmt.Appendf(nil, "neva: %s", pkg.Version),
 		0o644,
 	); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
 	// Create src sub-directory
 	srcPath := filepath.Join(path, "src")
 	if err := os.Mkdir(srcPath, 0o755); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
 	// Create main.neva file
 	// #nosec G306 -- new files are intended to be readable
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return os.WriteFile(
 		filepath.Join(srcPath, "main.neva"),
 		[]byte(mainNevaContent),
@@ -104,12 +104,12 @@ func createNevaMod(path string) error {
 func scaffoldFromTemplate(path string, template string) error {
 	spec, err := nevaGit.ParseRepoSpec(template)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
 	if spec.IsLocal() {
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return fmt.Errorf("local templates are not supported, use a remote repository URL")
 	}
 
@@ -150,11 +150,11 @@ func scaffoldFromTemplate(path string, template string) error {
 func ensureEmptyDir(path string) error {
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return os.MkdirAll(path, 0o755)
 	}
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	if !info.IsDir() {
@@ -162,7 +162,7 @@ func ensureEmptyDir(path string) error {
 	}
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	if len(entries) > 0 {
@@ -171,9 +171,9 @@ func ensureEmptyDir(path string) error {
 	return nil
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func copyDir(src, dst string) error {
-	//nolint:varnamelen,wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen,wrapcheck
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -181,7 +181,7 @@ func copyDir(src, dst string) error {
 
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 		if rel == "." {
@@ -201,7 +201,7 @@ func copyDir(src, dst string) error {
 
 		info, err := d.Info()
 		if err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 

--- a/internal/cli/osarch.go
+++ b/internal/cli/osarch.go
@@ -13,7 +13,7 @@ func newOSArchCmd() *cli.Command {
 		Name:  "osarch",
 		Usage: "List supported OS/architecture combinations for native target",
 		Action: func(cliCtx *cli.Context) error {
-			//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:noctx
 			cmd := exec.Command("go", "tool", "dist", "list")
 			output, err := cmd.Output()
 			if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,7 +19,7 @@ import (
 	"github.com/nevalang/neva/internal/compiler/desugarer"
 )
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func newRunCmd(
 	workdir string,
 	bldr builder.Builder,
@@ -134,7 +134,7 @@ func newRunCmd(
 				input.OutputPath = tempExecDir
 
 				if _, err := compilerToNative.Compile(ctx, input); err != nil {
-					//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:wrapcheck
 					return err
 				}
 

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -18,8 +18,8 @@ const (
 )
 
 //nolint:gocyclo // Control flow handles multiple run and watch edge cases.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func watchAndRun(ctx context.Context, moduleRoot string, run func(context.Context) error) error { //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func watchAndRun(ctx context.Context, moduleRoot string, run func(context.Context) error) error { //nolint:cyclop,funlen,gocognit,lll
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("create watcher: %w", err)
@@ -116,7 +116,7 @@ func watchAndRun(ctx context.Context, moduleRoot string, run func(context.Contex
 }
 
 func addWatchersRecursively(watcher *fsnotify.Watcher, root string) error {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/compiler/analyzer/analyzer.go
+++ b/internal/compiler/analyzer/analyzer.go
@@ -2,13 +2,13 @@
 // It's important to keep errors as human-readable as possible
 // because they are what end-user is facing when something goes wrong.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 package analyzer
 
 import (
 	"fmt"
 
-	//nolint:exptostd // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:exptostd
 	"golang.org/x/exp/maps"
 
 	"github.com/nevalang/neva/internal/compiler"
@@ -25,7 +25,7 @@ type Analyzer struct {
 // analyzer treats the build as an executable entry. When mainPkgName is empty,
 // analyzer only analyzes the build as a library.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (a Analyzer) Analyze(build src.Build, mainPkgName string) (src.Build, *compiler.Error) {
 	if mainPkgName == "" {
 		return a.analyzeBuild(build)
@@ -117,7 +117,7 @@ func (a Analyzer) analyzeModule(modRef core.ModuleRef, build src.Build) (map[str
 	}
 
 	pkgsCopy := make(map[string]src.Package, len(mod.Packages))
-	//nolint:exptostd // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:exptostd
 	maps.Copy(pkgsCopy, mod.Packages)
 
 	for pkgName, pkg := range pkgsCopy {
@@ -143,7 +143,7 @@ func (a Analyzer) analyzeModule(modRef core.ModuleRef, build src.Build) (map[str
 	return pkgsCopy, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzePkg(pkg src.Package, scope src.Scope) (src.Package, *compiler.Error) {
 	if len(pkg) == 0 {
 		return nil, &compiler.Error{
@@ -183,7 +183,7 @@ func (a Analyzer) analyzePkg(pkg src.Package, scope src.Scope) (src.Package, *co
 	return analyzedFiles, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzeEntity(entityName string, entity src.Entity, scope src.Scope) (src.Entity, *compiler.Error) {
 	resolvedEntity := src.Entity{
 		IsPublic: entity.IsPublic,
@@ -232,7 +232,7 @@ func (a Analyzer) analyzeEntity(entityName string, entity src.Entity, scope src.
 		resolvedEntity.Interface = resolvedInterface
 	case src.ComponentEntity:
 		analyzedVersions := make([]src.Component, 0, len(entity.Component))
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, component := range entity.Component {
 			analyzedComponent, err := a.analyzeComponent(entityName, component, scope)
 			if err != nil {

--- a/internal/compiler/analyzer/component.go
+++ b/internal/compiler/analyzer/component.go
@@ -7,9 +7,9 @@ import (
 
 func (a Analyzer) analyzeComponent(
 	componentName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	component src.Component,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.Component, *compiler.Error) {
 	externArg, hasExtern := component.Directives[compiler.ExternDirective]

--- a/internal/compiler/analyzer/const.go
+++ b/internal/compiler/analyzer/const.go
@@ -13,11 +13,11 @@ var (
 )
 
 //nolint:gocyclo // Const analysis handles many literal/type branches.
-//nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) analyzeConst( //nolint:cyclop,funlen,gocognit,lll,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx
+func (a Analyzer) analyzeConst( //nolint:cyclop,funlen,gocognit,lll,maintidx
+	//nolint:gocritic
 	constant src.Const,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.Const, *compiler.Error) {
 	if constant.Value.Message == nil && constant.Value.Ref == nil {

--- a/internal/compiler/analyzer/interface.go
+++ b/internal/compiler/analyzer/interface.go
@@ -18,9 +18,9 @@ type analyzeInterfaceParams struct {
 }
 
 func (a Analyzer) analyzeInterface(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	params analyzeInterfaceParams,
 ) (src.Interface, *compiler.Error) {
@@ -54,9 +54,9 @@ func (a Analyzer) analyzeInterface(
 
 func (a Analyzer) analyzeIO(
 	typeParams []ts.Param,
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	io src.IO,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	params analyzeInterfaceParams,
 ) (src.IO, *compiler.Error) {
@@ -99,11 +99,11 @@ func (a Analyzer) analyzeIO(
 func (a Analyzer) analyzePorts(
 	params []ts.Param,
 	ports map[string]src.Port,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (map[string]src.Port, *compiler.Error) {
 	resolvedPorts := make(map[string]src.Port, len(ports))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for name, port := range ports {
 		resolvedPort, err := a.analyzePort(params, port, scope)
 		if err != nil {
@@ -116,7 +116,7 @@ func (a Analyzer) analyzePorts(
 	return resolvedPorts, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzePort(params []ts.Param, port src.Port, scope src.Scope) (src.Port, *compiler.Error) {
 	// TODO https://github.com/nevalang/neva/issues/507
 	resolvedDef, err := a.analyzeType(

--- a/internal/compiler/analyzer/main_component.go
+++ b/internal/compiler/analyzer/main_component.go
@@ -7,7 +7,7 @@ import (
 	src "github.com/nevalang/neva/pkg/ast"
 )
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzeMainComponent(cmp src.Component, scope src.Scope) *compiler.Error {
 	if len(cmp.TypeParams.Params) != 0 {
 		return &compiler.Error{
@@ -27,7 +27,7 @@ func (a Analyzer) analyzeMainComponent(cmp src.Component, scope src.Scope) *comp
 	return nil
 }
 
-//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,varnamelen
 func (a Analyzer) analyzeMainFlowIO(io src.IO) *compiler.Error {
 	if len(io.In) != 1 {
 		return &compiler.Error{
@@ -42,7 +42,7 @@ func (a Analyzer) analyzeMainFlowIO(io src.IO) *compiler.Error {
 		}
 	}
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	enterInport, ok := io.In["start"]
 	if !ok {
 		return &compiler.Error{Message: "Main component must have 'start' inport", Meta: &io.Meta}
@@ -64,7 +64,7 @@ func (a Analyzer) analyzeMainFlowIO(io src.IO) *compiler.Error {
 	return nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzeMainComponentPort(port src.Port) *compiler.Error {
 	if port.IsArray {
 		return &compiler.Error{
@@ -83,10 +83,10 @@ func (a Analyzer) analyzeMainComponentPort(port src.Port) *compiler.Error {
 
 func (Analyzer) analyzeMainComponentNodes(
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) *compiler.Error {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, node := range nodes {
 		if _, err := scope.GetComponent(node.EntityRef); err != nil {
 			return &compiler.Error{

--- a/internal/compiler/analyzer/main_pkg.go
+++ b/internal/compiler/analyzer/main_pkg.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nevalang/neva/pkg/core"
 )
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) mainSpecificPkgValidation(mainPkgName string, mod src.Module, scope src.Scope) *compiler.Error {
 	mainPkg := mod.Packages[mainPkgName]
 

--- a/internal/compiler/analyzer/network.go
+++ b/internal/compiler/analyzer/network.go
@@ -2,7 +2,7 @@
 // Some methods here might look like they are related to senders or receivers specifically,
 // but they are actually related to both, so they are placed here.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 package analyzer
 
 import (
@@ -22,12 +22,12 @@ var ErrComplexLiteralSender = errors.New("literal network sender must have primi
 // analyzeNetwork must be called after analyzeNodes so we sure nodes are resolved.
 func (a Analyzer) analyzeNetwork(
 	net []src.Connection, // network to analyze
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface, // resolved interface of the component that contains the network
 	hasGuard bool, // whether `?` is used by at least one node in the network
 	nodes map[string]src.Node, // nodes of the component that contains the network
 	nodesIfaces map[string]foundInterface, // resolved interfaces of the nodes
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) ([]src.Connection, *compiler.Error) {
 	nodesUsage := make(map[string]netNodeUsage, len(nodes))
@@ -69,18 +69,18 @@ func (a Analyzer) analyzeNetwork(
 // analyzeConnections does two things:
 func (a Analyzer) analyzeConnections(
 	net []src.Connection,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
 	nodesUsage map[string]netNodeUsage,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	unionActiveTags map[string]unionActiveTagInfo,
 ) ([]src.Connection, *compiler.Error) {
 	analyzedConnections := make([]src.Connection, 0, len(net))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		resolvedConn, err := a.analyzeConnection(
 			conn,
@@ -105,13 +105,13 @@ func (a Analyzer) analyzeConnections(
 // 1. Analyzes every connection and terminates with non-nil error if any of them is invalid.
 // 2. Updates nodesUsage (we mutate it in-place instead of returning to avoid merging across recursive calls).
 func (a Analyzer) analyzeConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	nodesUsage map[string]netNodeUsage,
 	prevChainLink []src.ConnectionSender,
@@ -160,15 +160,15 @@ func (a Analyzer) analyzeConnection(
 	return analyzedConn, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func arrayBypassPortAddr(conn src.Connection) *src.PortAddr {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, sender := range conn.Senders {
 		if src.IsArrayBypassPortAddr(sender.PortAddr) {
 			return sender.PortAddr
 		}
 	}
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, receiver := range conn.Receivers {
 		if receiver.PortAddr != nil && src.IsArrayBypassPortAddr(receiver.PortAddr) {
 			return receiver.PortAddr
@@ -178,13 +178,13 @@ func arrayBypassPortAddr(conn src.Connection) *src.PortAddr {
 }
 
 func (a Analyzer) analyzeNormalConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	nodesUsage map[string]netNodeUsage,
 	prevChainLink []src.ConnectionSender,
@@ -241,7 +241,7 @@ func (a Analyzer) analyzeNormalConnection(
 	}, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func arrayBypassPorts(conn src.Connection) (*src.PortAddr, *src.PortAddr, bool) {
 	if len(conn.Senders) != 1 || len(conn.Receivers) != 1 {
 		return nil, nil, false
@@ -272,12 +272,12 @@ func (a Analyzer) patchSwitchSenders(
 	analyzedSenders []src.ConnectionSender,
 	resolvedSenderTypes []*ts.Expr,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	net []src.Connection,
 ) ([]src.ConnectionSender, []*ts.Expr, *compiler.Error) {
 	// Must run after sender normalization so switch:case[i] senders are resolved.
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	for i, sender := range analyzedSenders {
 		if sender.PortAddr == nil {
 			continue
@@ -302,15 +302,15 @@ func (a Analyzer) patchSwitchSenders(
 }
 
 func (a Analyzer) analyzeArrayBypassConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	senderPort src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiverPort src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	connMeta core.Meta,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -386,9 +386,9 @@ func (a Analyzer) analyzeArrayBypassConnection(
 }
 
 //nolint:gocyclo // Network port usage covers multiple connection kinds.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll
+	//nolint:gocritic
 	iface src.Interface, // resolved interface of the component that contains the network
 	nodesIfaces map[string]foundInterface, // resolved interfaces of the nodes in the network
 	hasGuard bool, // whether `?` is used by at least one node in the network
@@ -396,7 +396,7 @@ func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll // T
 	nodes map[string]src.Node,
 ) *compiler.Error {
 	// 1. every self inport must be used
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	inportsUsage, ok := nodesUsage["in"]
 	if !ok {
 		allInports := make([]string, 0, len(iface.IO.In))
@@ -448,7 +448,7 @@ func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll // T
 	}
 
 	// 3. check sub-nodes usage in network
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, nodeIface := range nodesIfaces {
 		nodeMeta := nodes[nodeName].Meta
 
@@ -529,7 +529,7 @@ func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll // T
 				}
 			}
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			for i := uint8(0); i <= maxSlot; i++ {
 				if _, ok := usedSlots[i]; !ok {
 					return &compiler.Error{
@@ -557,7 +557,7 @@ func (a Analyzer) analyzeNetPortsUsage( //nolint:cyclop,funlen,gocognit,lll // T
 				}
 			}
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			for i := uint8(0); i <= maxSlot; i++ {
 				if _, ok := usedSlots[i]; !ok {
 					return &compiler.Error{
@@ -590,11 +590,11 @@ func unusedPortsMessage(portType string, ports []string) string {
 func (a Analyzer) getResolvedPortType(
 	ports map[string]src.Port,
 	nodeIfaceParams []ts.Param,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	isInput bool,
 ) (src.PortAddr, ts.Expr, bool, *compiler.Error) {
@@ -632,9 +632,9 @@ func (a Analyzer) getResolvedPortType(
 
 func (a Analyzer) resolveUnnamedPort(
 	ports map[string]src.Port,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node,
 	isInput bool,
 ) (src.PortAddr, *compiler.Error) {
@@ -672,16 +672,16 @@ func (a Analyzer) resolveUnnamedPort(
 }
 
 func (a Analyzer) resolvePortTypeWithFrame(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	port src.Port,
 	nodeIfaceParams []ts.Param,
 	resolvedNodeArgs []ts.Expr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (ts.Expr, *compiler.Error) {
 	// we don't resolve node's args assuming they resolved already
 	frame := make(map[string]ts.Def, len(nodeIfaceParams))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range nodeIfaceParams {
 		arg := resolvedNodeArgs[i]
 		frame[param.Name] = ts.Def{
@@ -706,13 +706,13 @@ func (a Analyzer) resolvePortTypeWithFrame(
 }
 
 func (a Analyzer) getResolvedSenderType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	prevChainLink []src.ConnectionSender,
 ) (src.ConnectionSender, ts.Expr, bool, *compiler.Error) {
@@ -780,11 +780,11 @@ func (a Analyzer) getResolvedSenderType(
 // getPortSenderType returns resolved port-addr, type expr and isArray bool.
 // Resolved port is equal to the given one unless it was an "" empty string.
 func (a Analyzer) getPortSenderType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	senderSidePortAddr src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -828,9 +828,9 @@ func (a Analyzer) getPortSenderType(
 }
 
 func (a Analyzer) getConstSenderType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	constSender src.Const,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.Const, ts.Expr, *compiler.Error) {
 	if constSender.Value.Ref != nil {
@@ -889,7 +889,7 @@ func (a Analyzer) getConstSenderType(
 // validateLiteralSender allows only primitive literals and union literals for now.
 // Complex literals (list/dict/struct) are rejected for simplicity; use const refs instead.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) validateLiteralSender(resolvedExpr ts.Expr) error {
 	if resolvedExpr.Inst != nil {
 		switch resolvedExpr.Inst.Ref.String() {
@@ -910,14 +910,14 @@ func (a Analyzer) validateLiteralSender(resolvedExpr ts.Expr) error {
 // getNodeOutportType returns resolved port-addr, type expr and isArray bool.
 // Resolved port is equal to the given one unless it was an "" empty string.
 func (a Analyzer) getNodeOutportType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.PortAddr, ts.Expr, bool, *compiler.Error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	node, ok := nodes[portAddr.Node]
 	if !ok {
 		return src.PortAddr{}, ts.Expr{}, false, &compiler.Error{
@@ -950,9 +950,9 @@ func (a Analyzer) getNodeOutportType(
 }
 
 func (a Analyzer) getResolvedConstTypeByRef(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	ref core.EntityRef,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (ts.Expr, *compiler.Error) {
 	constant, loc, err := scope.GetConst(ref)
@@ -987,10 +987,10 @@ func (a Analyzer) getResolvedConstTypeByRef(
 }
 
 func (a Analyzer) getSelectorsSenderType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	senderType ts.Expr,
 	selectors []string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (ts.Expr, *compiler.Error) {
 	if len(selectors) == 0 {

--- a/internal/compiler/analyzer/network_test.go
+++ b/internal/compiler/analyzer/network_test.go
@@ -56,7 +56,7 @@ func TestCreateSingleElementUnion(t *testing.T) {
 // createSingleElementUnion creates a union type with a single element matching the given type.
 // It's used only by unit tests.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) createSingleElementUnion(expr ts.Expr) ts.Expr {
 	// if the expression is already a union, return it as-is
 	if expr.Lit != nil && expr.Lit.Union != nil {

--- a/internal/compiler/analyzer/nodes.go
+++ b/internal/compiler/analyzer/nodes.go
@@ -17,11 +17,11 @@ type foundInterface struct {
 
 func (a Analyzer) analyzeNodes(
 	parentComponentName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface, // resolved interface of the component that contains the nodes
 	nodes map[string]src.Node, // nodes to analyze
 	net []src.Connection, // network of the component that contains the nodes
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope, // scope of the component
 ) (
 	map[string]src.Node, // resolved nodes
@@ -33,7 +33,7 @@ func (a Analyzer) analyzeNodes(
 	nodesInterfaces := make(map[string]foundInterface, len(nodes))
 	hasErrGuard := false
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, node := range nodes {
 		if isMissingNodeName(nodeName) {
 			return nil, nil, false, &compiler.Error{
@@ -75,15 +75,15 @@ func isMissingNodeName(nodeName string) bool {
 }
 
 //nolint:gocyclo // Analyzer node handling is a high-branch routine.
-//nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) analyzeNode( //nolint:cyclop,funlen,gocognit,lll,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx
+func (a Analyzer) analyzeNode( //nolint:cyclop,funlen,gocognit,lll,maintidx
 	name string, // name of the node
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node, // node to analyze
 	parentComponentName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope, // scope of the component that contains the node
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface, // interface of the component that contains the node
 	nodes map[string]src.Node, // nodes of the component that contains the node
 	net []src.Connection, // network of the component that contains the node
@@ -258,7 +258,7 @@ func (a Analyzer) analyzeNode( //nolint:cyclop,funlen,gocognit,lll,maintidx // T
 	}
 
 	resolvedFlowDI := make(map[string]src.Node, len(node.DIArgs))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for depName, depNode := range node.DIArgs {
 		// di arguments are not regular nodes in the network, so we generate a unique name
 		// that won't be found in the network. This will cause the overloading logic to skip
@@ -298,18 +298,18 @@ func (a Analyzer) analyzeNode( //nolint:cyclop,funlen,gocognit,lll,maintidx // T
 // getInterfaceAndOverloadingIndexForNode returns interface and overload index for the given node.
 // Overloading at the level of sourcecode is implemented here.
 //
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (a Analyzer) getInterfaceAndOverloadingIndexForNode(
 	nodeName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	entity src.Entity,
 	hasBind bool,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	resolvedNodeArgs []typesystem.Expr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	resolvedParentIface src.Interface, // resolved interface of the component that contains the node
 	allParentNodes map[string]src.Node, // nodes of the component that contains the node
 	net []src.Connection, // network of the component that contains the node
@@ -409,7 +409,7 @@ func (a Analyzer) getInterfaceAndOverloadingIndexForNode(
 
 	structFields := resolvedNodeArg.Lit.Struct
 	inports := make(map[string]src.Port, len(structFields))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for fieldName, fieldTypeExpr := range structFields {
 		inports[fieldName] = src.Port{
 			TypeExpr: fieldTypeExpr,
@@ -437,17 +437,17 @@ func (a Analyzer) getInterfaceAndOverloadingIndexForNode(
 // This is called when we know the node references an overloaded component with multiple implementations.
 // It analyzes how the node is used in connections to determine the appropriate implementation.
 //
-//nolint:funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:funlen,gocognit
 func (a Analyzer) getNodeOverloadVersionAndIndex(
 	nodeName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	resolvedParentIface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	resolvedNodeArgs []typesystem.Expr,
 	allParentNodes map[string]src.Node,
 	net []src.Connection,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	entity src.Entity,
 ) (src.Component, *int, *compiler.Error) {
 	nodeRefs := findNodeRefsInNet(nodeName, net)
@@ -478,7 +478,7 @@ func (a Analyzer) getNodeOverloadVersionAndIndex(
 
 	remainingIdx := make([]int, 0, len(entity.Component))
 	remainingComps := make([]src.Component, 0, len(entity.Component))
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	for i, component := range entity.Component {
 		// skip network-based compatibility check for di arguments
 		if !isDIArg {
@@ -489,7 +489,7 @@ func (a Analyzer) getNodeOverloadVersionAndIndex(
 
 		// for native components with multiple extern implementations, use type argument-based disambiguation
 		// this handles cases like Dec(int) vs Dec(float) or Len(list) vs Len(string)
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if a.isNativeComponentWithMultipleExterns(component, entity) {
 			// if we have type arguments, use them for disambiguation
 			if len(resolvedNodeArgs) > 0 {
@@ -553,10 +553,10 @@ func (a Analyzer) getNodeOverloadVersionAndIndex(
 // from the parent component's dependency declaration.
 //
 //nolint:gocyclo // DI constraint derivation has multiple cases to check.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,gocognit,lll
 	nodeName string, // the unique name of the DI argument (e.g., "__di_reduce_reducer")
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	allParentNodes map[string]src.Node,
 ) nodeUsageConstraints {
@@ -580,7 +580,7 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 	// we need to look through all parent nodes to find the one that has this dependency
 	var parentNodeName string
 	var parentNode src.Node
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, node := range allParentNodes {
 		if node.DIArgs != nil {
 			if _, hasDep := node.DIArgs[depName]; hasDep {
@@ -622,7 +622,7 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 
 	if depName == "" {
 		// for anonymous dependencies, find the first interface node
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, node := range parentComponent.Nodes {
 			entity, _, err := parentScope.Entity(node.EntityRef)
 			if err == nil && entity.Kind == src.InterfaceEntity {
@@ -653,7 +653,7 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 	// we need to create a frame from the parent's type arguments
 	// the parent component's original interface has the type parameters
 	parentTypeFrame := make(map[string]typesystem.Def)
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range parentComponent.TypeParams.Params {
 		if i < len(parentNode.TypeArgs) {
 			parentTypeFrame[param.Name] = typesystem.Def{
@@ -670,7 +670,7 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 	}
 
 	// add incoming constraints (input ports) - resolve each port type with the parent's type frame
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for portName, port := range depEntity.Interface.IO.In {
 		resolvedType, err := a.resolver.ResolveExprWithFrame(port.TypeExpr, parentTypeFrame, scope)
 		if err != nil {
@@ -680,7 +680,7 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 	}
 
 	// add outgoing constraints (output ports) - resolve each port type with the parent's type frame
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for portName, port := range depEntity.Interface.IO.Out {
 		resolvedType, err := a.resolver.ResolveExprWithFrame(port.TypeExpr, parentTypeFrame, scope)
 		if err != nil {
@@ -726,9 +726,9 @@ func (a Analyzer) collectDITypeConstraintsFromParent( //nolint:cyclop,funlen,goc
 // Compatibility is checked by comparing the port types and array usage.
 // The type of the port ignored for now, to be checked later.
 //
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func isCandidateCompatibleWithAllNodeRefs(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	component src.Component,
 	nodeRefs []nodeRefInNet,
 ) bool {
@@ -773,9 +773,9 @@ func isCandidateCompatibleWithAllNodeRefs(
 func findNodeRefsInNet(nodeName string, connections []src.Connection) []nodeRefInNet {
 	var refs []nodeRefInNet
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range connections {
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, sender := range conn.Senders {
 			if sender.PortAddr != nil && sender.PortAddr.Node == nodeName {
 				refs = append(refs, nodeRefInNet{
@@ -795,7 +795,7 @@ func findNodeRefsInNet(nodeName string, connections []src.Connection) []nodeRefI
 func findNodeUsagesInReceivers(nodeName string, receivers []src.ConnectionReceiver) []nodeRefInNet {
 	var nodeRefs []nodeRefInNet
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, receiver := range receivers {
 		// Check direct port address
 		if receiver.PortAddr != nil && receiver.PortAddr.Node == nodeName {
@@ -809,7 +809,7 @@ func findNodeUsagesInReceivers(nodeName string, receivers []src.ConnectionReceiv
 		// Check chained connection
 		if receiver.ChainedConnection != nil {
 			// Check senders in the chain
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, sender := range receiver.ChainedConnection.Senders {
 				if sender.PortAddr != nil && sender.PortAddr.Node == nodeName {
 					nodeRefs = append(nodeRefs, nodeRefInNet{
@@ -852,10 +852,10 @@ func emptyConstraints() nodeUsageConstraints {
 // We use string form here because analyzer already treats typesystem.Expr.String()
 // as canonical identity (see typesMatchExactly).
 //
-//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,varnamelen
 func appendUniqueType(dst *[]typesystem.Expr, t typesystem.Expr) {
 	s := t.String()
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, existing := range *dst {
 		if existing.String() == s {
 			return
@@ -883,7 +883,7 @@ func singleUnambiguousType(candidates []typesystem.Expr) (typesystem.Expr, bool)
 // aTypesMatchExactly keeps type equivalence logic centralized for helpers that
 // are outside Analyzer methods.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func aTypesMatchExactly(type1, type2 typesystem.Expr) bool {
 	return type1.String() == type2.String()
 }
@@ -893,17 +893,17 @@ func aTypesMatchExactly(type1, type2 typesystem.Expr) bool {
 // It is needed only to select correct version of the overloaded component.
 //
 //nolint:gocyclo // Node constraint derivation handles many network patterns.
-//nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocognit,lll,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx
+func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocognit,lll,maintidx
 	nodeName string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	resolvedParentIface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	nodes map[string]src.Node,
 	net []src.Connection,
 ) nodeUsageConstraints {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	c := nodeUsageConstraints{
 		incoming: map[string][]typesystem.Expr{},
 		outgoing: map[string][]typesystem.Expr{},
@@ -924,10 +924,10 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 	}
 
 	// walk all connections
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		// check if our node is a sender in this connection (including chained connections)
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, sender := range conn.Senders {
 			if sender.PortAddr == nil || sender.PortAddr.Node != nodeName {
 				continue
@@ -935,7 +935,7 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 			port := a.resolvePortName(nodeName, nodes, scope, false, sender.PortAddr.Port)
 			// derive expected types from all receivers
 			recvPortAddrs := a.flattenReceiversPortAddrs(conn.Receivers)
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, rpa := range recvPortAddrs {
 				// parent out
 				if rpa.Node == "out" {
@@ -964,13 +964,13 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 			}
 
 			// also check chained connections for outgoing constraints
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, receiver := range conn.Receivers {
-				//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:nestif
 				if receiver.ChainedConnection != nil {
 					// this is a chained connection, look at the receivers within the chain
 					chainedRecvPortAddrs := a.flattenReceiversPortAddrs(receiver.ChainedConnection.Receivers)
-					//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:gocritic
 					for _, rpa := range chainedRecvPortAddrs {
 						// parent out
 						if rpa.Node == "out" {
@@ -1006,11 +1006,11 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 		// this needs to be recursive to handle nested chains like "a -> b -> c -> d"
 		var checkChainedConnections func(outerSenders []src.ConnectionSender, receivers []src.ConnectionReceiver)
 		checkChainedConnections = func(outerSenders []src.ConnectionSender, receivers []src.ConnectionReceiver) {
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, receiver := range receivers {
-				//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:nestif
 				if receiver.ChainedConnection != nil {
-					//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:gocritic
 					for _, sender := range receiver.ChainedConnection.Senders {
 						if sender.PortAddr == nil || sender.PortAddr.Node != nodeName {
 							continue
@@ -1021,7 +1021,7 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 						inPort := a.resolvePortName(nodeName, nodes, scope, true, "")
 
 						// collect types from the outer senders
-						//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+						//nolint:gocritic
 						for _, outerSender := range outerSenders {
 							types := a.getPossibleSenderTypes(
 								scope,
@@ -1033,7 +1033,7 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 								nil,
 								net,
 							)
-							//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+							//nolint:gocritic
 							for _, t := range types {
 								list := c.incoming[inPort]
 								appendUniqueType(&list, t)
@@ -1044,7 +1044,7 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 						// collect outgoing constraints from the chained connection's receivers
 						port := a.resolvePortName(nodeName, nodes, scope, false, sender.PortAddr.Port)
 						chainedRecvPortAddrs := a.flattenReceiversPortAddrs(receiver.ChainedConnection.Receivers)
-						//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+						//nolint:gocritic
 						for _, rpa := range chainedRecvPortAddrs {
 							if rpa.Node == "out" {
 								if p, ok := resolvedParentIface.IO.Out[rpa.Port]; ok {
@@ -1080,13 +1080,13 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 
 		// Check if our node is a receiver in this connection.
 		recvPairs := a.collectReceiverSenderPairs(conn.Receivers, conn.Senders)
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, pair := range recvPairs {
 			if pair.portAddr.Node != nodeName {
 				continue
 			}
 			port := a.resolvePortName(nodeName, nodes, scope, true, pair.portAddr.Port)
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, sender := range pair.senders {
 				types := a.getPossibleSenderTypes(
 					scope,
@@ -1097,7 +1097,7 @@ func (a Analyzer) deriveNodeConstraintsFromNetwork( //nolint:cyclop,funlen,gocog
 					pair.prevChainLink,
 					net,
 				)
-				//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:gocritic
 				for _, t := range types {
 					list := c.incoming[port]
 					appendUniqueType(&list, t)
@@ -1126,7 +1126,7 @@ func (a Analyzer) flattenReceiversPortAddrs(receivers []src.ConnectionReceiver) 
 	var res []src.PortAddr
 	var visit func(recs []src.ConnectionReceiver)
 	visit = func(recs []src.ConnectionReceiver) {
-		//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic,varnamelen
 		for _, r := range recs {
 			if r.PortAddr != nil {
 				res = append(res, *r.PortAddr)
@@ -1154,7 +1154,7 @@ func collectReceiverSenderPairsRec(
 	snd []src.ConnectionSender,
 	prevChainLink []src.ConnectionSender,
 ) {
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	for _, r := range recs {
 		if r.PortAddr != nil {
 			*pairs = append(*pairs, receiverSenderPair{
@@ -1199,21 +1199,21 @@ func (a Analyzer) collectReceiverSenderPairs(
 // Later regular sender/receiver validation emits concrete diagnostics.
 //
 //nolint:gocyclo // This centralizes sender forms (const/selector/port) for consistent constraint derivation.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll
+	//nolint:gocritic
 	scope src.Scope,
 	parentFrame map[string]typesystem.Def,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	parentIface src.Interface,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
 	prevChainLink []src.ConnectionSender,
 	net []src.Connection,
 ) []typesystem.Expr {
 	// const sender
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if sender.Const != nil {
 		// for type constraint collection, we need to get the resolved type without validation
 		// since we're just collecting constraints, not validating the sender
@@ -1239,7 +1239,7 @@ func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll //
 		}
 
 		var selectorTypes []typesystem.Expr
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, chainHead := range prevChainLink {
 			headTypes := a.getPossibleSenderTypes(
 				scope,
@@ -1250,7 +1250,7 @@ func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll //
 				nil,
 				net,
 			)
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, headType := range headTypes {
 				resolvedSelectorType, err := a.getSelectorsSenderType(headType, sender.StructSelector, scope)
 				if err != nil {
@@ -1267,7 +1267,7 @@ func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll //
 	}
 
 	// port-addr
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if sender.PortAddr != nil {
 		// Switch:case[i] array outport slot is a special case because of possible pattern matching.
 		// When T in Switch<T> is (resolves to) union, and corresponding union member has type expression body,
@@ -1333,12 +1333,12 @@ func (a Analyzer) getPossibleSenderTypes( //nolint:cyclop,funlen,gocognit,lll //
 // It can return an empty set when the entity/port cannot be resolved in this
 // phase or when no overload yields a resolvable type for the requested port.
 //
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func (a Analyzer) getPossibleNodePortTypes(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	parentFrame map[string]typesystem.Def,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node,
 	isInput bool,
 	portName string,
@@ -1354,19 +1354,19 @@ func (a Analyzer) getPossibleNodePortTypes(
 	if err2 != nil {
 		return out
 	}
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, comp := range entity.Component {
 		iface := comp.Interface
 		// choose port
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		var p src.Port
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		var ok bool
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if isInput {
 			if portName == "" {
 				if len(iface.IO.In) == 1 {
-					//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:gocritic
 					for _, v := range iface.IO.In {
 						p = v
 						ok = true
@@ -1380,14 +1380,14 @@ func (a Analyzer) getPossibleNodePortTypes(
 			if portName == "" {
 				// if multiple, prefer first non-err
 				if len(iface.IO.Out) == 1 {
-					//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:gocritic
 					for _, v := range iface.IO.Out {
 						p = v
 						ok = true
 						break
 					}
 				} else {
-					//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:gocritic
 					for name, v := range iface.IO.Out {
 						if name != "err" {
 							p = v
@@ -1405,7 +1405,7 @@ func (a Analyzer) getPossibleNodePortTypes(
 		}
 		// substitute node args into port type
 		frame := make(map[string]typesystem.Def, len(iface.TypeParams.Params))
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for i, param := range iface.TypeParams.Params {
 			if i < len(resolvedArgs) {
 				frame[param.Name] = typesystem.Def{BodyExpr: &resolvedArgs[i]}
@@ -1420,18 +1420,18 @@ func (a Analyzer) getPossibleNodePortTypes(
 
 // doesCandidateSatisfyTypeConstraints checks that a candidate interface matches all collected constraints.
 //
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func (a Analyzer) doesCandidateSatisfyTypeConstraints(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	candidate src.Interface,
 	resolvedNodeArgs []typesystem.Expr,
 	nodeUsageConstr nodeUsageConstraints,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) bool {
 	// build frame for candidate from node's resolved args
 	frame := make(map[string]typesystem.Def, len(candidate.TypeParams.Params))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range candidate.TypeParams.Params {
 		if i < len(resolvedNodeArgs) {
 			frame[param.Name] = typesystem.Def{BodyExpr: &resolvedNodeArgs[i]}
@@ -1448,7 +1448,7 @@ func (a Analyzer) doesCandidateSatisfyTypeConstraints(
 		if err != nil {
 			return false
 		}
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, t := range types {
 			if a.resolver.IsSubtypeOf(t, candType, scope) != nil {
 				return false
@@ -1466,7 +1466,7 @@ func (a Analyzer) doesCandidateSatisfyTypeConstraints(
 		if err != nil {
 			return false
 		}
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for _, exp := range types {
 			if err := a.resolver.IsSubtypeOf(candType, exp, scope); err != nil {
 				return false
@@ -1480,7 +1480,7 @@ func (a Analyzer) doesCandidateSatisfyTypeConstraints(
 // isNativeComponentWithMultipleExterns checks if this is a native component with multiple extern implementations
 // (like Dec with int_dec and float_dec, or Len with list_len, map_len, and string_len)
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) isNativeComponentWithMultipleExterns(component src.Component, entity src.Entity) bool {
 	// check if this component has extern directive
 	_, hasExtern := component.Directives[compiler.ExternDirective]
@@ -1495,7 +1495,7 @@ func (a Analyzer) isNativeComponentWithMultipleExterns(component src.Component, 
 // doesNativeComponentMatchTypeArgs checks if a native component's interface matches the type arguments
 // this is used for disambiguating between overloaded native components like Dec(int) vs Dec(float)
 //
-//nolint:gocognit,gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,gocritic
 func (a Analyzer) doesNativeComponentMatchTypeArgs(component src.Component, resolvedNodeArgs []typesystem.Expr, scope src.Scope) bool {
 	// for native components, we need to check if the type arguments match the component's interface
 	// for example, if we have Dec<int>, we need to find the component with Dec(data int) (res int)
@@ -1506,7 +1506,7 @@ func (a Analyzer) doesNativeComponentMatchTypeArgs(component src.Component, reso
 	}
 
 	// resolve the first type argument to get the concrete type
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if len(resolvedNodeArgs) > 0 {
 		resolvedType, err := a.resolver.ResolveExpr(resolvedNodeArgs[0], scope)
 		if err != nil {
@@ -1516,7 +1516,7 @@ func (a Analyzer) doesNativeComponentMatchTypeArgs(component src.Component, reso
 		// check if this component's interface matches the resolved type
 		// for native components, we need to check the input port type
 		if len(component.IO.In) == 1 {
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, port := range component.IO.In {
 				// resolve the port type
 				portType, err := a.resolver.ResolveExpr(port.TypeExpr, scope)
@@ -1539,7 +1539,7 @@ func (a Analyzer) doesNativeComponentMatchTypeArgs(component src.Component, reso
 // typesMatchExactly checks if two types match exactly (for native component disambiguation)
 // uses string comparison as a simple and reliable equality check
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) typesMatchExactly(type1, type2 typesystem.Expr) bool {
 	return type1.String() == type2.String()
 }
@@ -1550,7 +1550,7 @@ func (a Analyzer) typesMatchExactly(type1, type2 typesystem.Expr) bool {
 func (a Analyzer) resolvePortName(
 	nodeName string,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	isInput bool,
 	portName string,

--- a/internal/compiler/analyzer/receivers.go
+++ b/internal/compiler/analyzer/receivers.go
@@ -11,9 +11,9 @@ import (
 
 func (a Analyzer) analyzeReceivers(
 	receiverSide []src.ConnectionReceiver,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -25,7 +25,7 @@ func (a Analyzer) analyzeReceivers(
 ) ([]src.ConnectionReceiver, *compiler.Error) {
 	analyzedReceivers := make([]src.ConnectionReceiver, 0, len(receiverSide))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, receiver := range receiverSide {
 		analyzedReceiver, err := a.analyzeReceiver(
 			receiver,
@@ -50,11 +50,11 @@ func (a Analyzer) analyzeReceivers(
 }
 
 func (a Analyzer) analyzeReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiver src.ConnectionReceiver,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -112,11 +112,11 @@ func (a Analyzer) analyzeReceiver(
 }
 
 func (a Analyzer) analyzePortAddrReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -193,11 +193,11 @@ func (a Analyzer) analyzePortAddrReceiver(
 }
 
 func (a Analyzer) analyzeChainedConnectionReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	chainedConn src.Connection,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -282,7 +282,7 @@ func (a Analyzer) analyzeChainedConnectionReceiver(
 
 // isUnionDataReceiver reports whether a port address targets Union:data with a known active tag.
 func isUnionDataReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 	unionActiveTags map[string]unionActiveTagInfo,
 ) bool {
@@ -296,13 +296,13 @@ func isUnionDataReceiver(
 // getReceiverPortType returns resolved port-addr, type expr and isArray bool.
 // Resolved port is equal to the given one unless it was an "" empty string.
 func (a Analyzer) getReceiverPortType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiverSide src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.PortAddr, ts.Expr, bool, *compiler.Error) {
 	if receiverSide.Node == "in" {
@@ -353,14 +353,14 @@ func (a Analyzer) getReceiverPortType(
 // getNodeInportType returns resolved port-addr, type expr and isArray bool.
 // Resolved port is equal to the given one unless it was an "" empty string.
 func (a Analyzer) getNodeInportType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.PortAddr, ts.Expr, bool, *compiler.Error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	node, ok := nodes[portAddr.Node]
 	if !ok {
 		return src.PortAddr{}, ts.Expr{}, false, &compiler.Error{
@@ -394,7 +394,7 @@ func (a Analyzer) getNodeInportType(
 	return resolvedPortAddr, resolvedInportType, isArray, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Analyzer) getStructSelectorInportType(chainHead src.ConnectionSender) ts.Expr {
 	// build nested struct type for selectors
 	typeExpr := ts.Expr{

--- a/internal/compiler/analyzer/senders.go
+++ b/internal/compiler/analyzer/senders.go
@@ -9,9 +9,9 @@ import (
 
 func (a Analyzer) analyzeSenders(
 	senders []src.ConnectionSender,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -21,7 +21,7 @@ func (a Analyzer) analyzeSenders(
 	analyzedSenders := make([]src.ConnectionSender, 0, len(senders))
 	resolvedSenderTypes := make([]*ts.Expr, 0, len(senders))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, sender := range senders {
 		analyzedSender, expr, err := a.analyzeSender(
 			sender,
@@ -51,13 +51,13 @@ func (a Analyzer) analyzeSenders(
 
 // analyzeSender validates sender, marks it as used if it's port-address and returns its type.
 //
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (a Analyzer) analyzeSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
@@ -103,7 +103,7 @@ func (a Analyzer) analyzeSender(
 		}.Wrap(err)
 	}
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if sender.PortAddr != nil {
 		if !isSenderArr && sender.PortAddr.Idx != nil {
 			return nil, nil, &compiler.Error{
@@ -147,11 +147,11 @@ func (a Analyzer) analyzeSender(
 }
 
 func (a Analyzer) getChainHeadInputType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	chainHead src.ConnectionSender,
 	nodes map[string]src.Node,
 	nodesIfaces map[string]foundInterface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (ts.Expr, *compiler.Error) {
 	if chainHead.PortAddr != nil {

--- a/internal/compiler/analyzer/switch_logic.go
+++ b/internal/compiler/analyzer/switch_logic.go
@@ -14,15 +14,15 @@ import (
 // to determine which Union tag matches this case, and returns that tag's type.
 // If T is not a Union, it returns nil (meaning standard T applies).
 func (a Analyzer) getSwitchCaseOutportType(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	switchPort src.PortAddr,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	net []src.Connection,
 ) (*ts.Expr, *compiler.Error) {
 	// 1. Get Switch Node to check if T is Union
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	node, ok := nodes[switchPort.Node]
 	if !ok {
 		panic("switch node not found")
@@ -86,9 +86,9 @@ func (a Analyzer) getSwitchCaseOutportType(
 }
 
 func (a Analyzer) getUnionTagFromSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (string, *compiler.Error) {
 	if sender.Const == nil {
@@ -117,9 +117,9 @@ func (a Analyzer) getUnionTagFromSender(
 }
 
 func (a Analyzer) resolveUnionConstRef(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	ref core.EntityRef,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (*src.UnionLiteral, *compiler.Error) {
 	constant, loc, err := scope.GetConst(ref)
@@ -148,10 +148,10 @@ func (a Analyzer) findSenderForSwitchCaseInput(
 	net []src.Connection,
 	nodeName string,
 	idx *uint8,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	switchPort src.PortAddr,
 ) (*src.ConnectionSender, *compiler.Error) {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		sender, err := a.findSenderForSwitchCaseInputInConn(&conn, nodeName, idx)
 		if err != nil {
@@ -176,14 +176,14 @@ func (a Analyzer) findSenderForSwitchCaseInputInConn(
 	return a.findSenderForSwitchCaseInportInConn(*conn, nodeName, idx)
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (a Analyzer) findSenderForSwitchCaseInportInConn(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection,
 	nodeName string,
 	idx *uint8,
 ) (*src.ConnectionSender, *compiler.Error) {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, receiver := range conn.Receivers {
 		// Receiver is `... -> switch:case[i]`
 		if a.isSwitchCaseReceiver(receiver, nodeName, idx) {
@@ -198,7 +198,7 @@ func (a Analyzer) findSenderForSwitchCaseInportInConn(
 
 		// Check chained connection
 		// ... -> switch:case[i] -> ...
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if receiver.ChainedConnection != nil {
 			if len(receiver.ChainedConnection.Senders) > 0 {
 				chainHead := receiver.ChainedConnection.Senders[0]
@@ -231,7 +231,7 @@ func (a Analyzer) findSenderForSwitchCaseInportInConn(
 	return nil, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Analyzer) isSwitchCaseSender(sender src.ConnectionSender, nodeName string, idx *uint8) bool {
 	return sender.PortAddr != nil &&
 		sender.PortAddr.Node == nodeName &&
@@ -240,7 +240,7 @@ func (Analyzer) isSwitchCaseSender(sender src.ConnectionSender, nodeName string,
 		*sender.PortAddr.Idx == *idx
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Analyzer) isSwitchCaseReceiver(receiver src.ConnectionReceiver, nodeName string, idx *uint8) bool {
 	return receiver.PortAddr != nil &&
 		receiver.PortAddr.Node == nodeName &&
@@ -251,7 +251,7 @@ func (Analyzer) isSwitchCaseReceiver(receiver src.ConnectionReceiver, nodeName s
 
 // isSwitchCasePort checks if a port address refers to a Switch component's case port.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func isSwitchCasePort(portAddr src.PortAddr, nodes map[string]src.Node) bool {
 	node, ok := nodes[portAddr.Node]
 	if !ok {

--- a/internal/compiler/analyzer/type.go
+++ b/internal/compiler/analyzer/type.go
@@ -10,7 +10,7 @@ type analyzeTypeDefParams struct {
 	allowEmptyBody bool
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzeType(def ts.Def, scope src.Scope, params analyzeTypeDefParams) (ts.Def, *compiler.Error) {
 	if !params.allowEmptyBody && def.BodyExpr == nil {
 		meta := def.Meta
@@ -38,7 +38,7 @@ func (a Analyzer) analyzeType(def ts.Def, scope src.Scope, params analyzeTypeDef
 	}, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) analyzeTypeExpr(expr ts.Expr, scope src.Scope) (ts.Expr, *compiler.Error) {
 	resolvedExpr, err := a.resolver.ResolveExpr(expr, scope)
 	if err != nil {
@@ -53,7 +53,7 @@ func (a Analyzer) analyzeTypeExpr(expr ts.Expr, scope src.Scope) (ts.Expr, *comp
 
 func (a Analyzer) analyzeTypeParams(
 	params []ts.Param,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (
 	[]ts.Param,

--- a/internal/compiler/analyzer/union_logic.go
+++ b/internal/compiler/analyzer/union_logic.go
@@ -17,16 +17,16 @@ type unionActiveTagInfo struct {
 // is active for each Union<T> node (via its :tag port). It returns a map from Union node name
 // to the active tag and its payload type, so Union:data connections can be validated.
 //
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (a Analyzer) buildUnionActiveTagBindings(
 	net []src.Connection,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (map[string]unionActiveTagInfo, *compiler.Error) {
 	infos := map[string]unionActiveTagInfo{}
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, node := range nodes {
 		// Only Union<T> nodes participate in tag/data validation.
 		if !a.isUnionNode(node) {
@@ -109,12 +109,12 @@ func (a Analyzer) buildUnionActiveTagBindings(
 // validateUnionDataReceiverPort checks a single port address and applies the Union:data constraint
 // if the receiver is a Union node with a resolved active tag type.
 func (a Analyzer) validateUnionDataReceiverPort(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 	senders []src.ConnectionSender,
 	resolvedSenderTypes []*ts.Expr,
 	unionActiveTags map[string]unionActiveTagInfo,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) *compiler.Error {
 	tagInfo, ok := unionActiveTags[portAddr.Node]
@@ -124,7 +124,7 @@ func (a Analyzer) validateUnionDataReceiverPort(
 	}
 
 	// All senders must be subtype-compatible with the selected tag payload type.
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for i, senderType := range resolvedSenderTypes {
 		if err := a.resolver.IsSubtypeOf(*senderType, tagInfo.tagTypeExpr, scope); err != nil {
 			return &compiler.Error{
@@ -152,7 +152,7 @@ func (a Analyzer) collectPortSenders(
 ) []src.ConnectionSender {
 	var out []src.ConnectionSender
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		a.collectPortSendersInReceivers(
 			conn.Senders,
@@ -169,7 +169,7 @@ func (a Analyzer) collectPortSenders(
 // collectPortSendersInReceivers is the recursive worker that walks receiver trees
 // and appends matching senders into out.
 //
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (a Analyzer) collectPortSendersInReceivers(
 	senders []src.ConnectionSender,
 	receivers []src.ConnectionReceiver,
@@ -177,7 +177,7 @@ func (a Analyzer) collectPortSendersInReceivers(
 	port string,
 	out *[]src.ConnectionSender,
 ) {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, receiver := range receivers {
 		// Direct receiver: outer senders feed nodeName:port.
 		if receiver.PortAddr != nil {
@@ -188,7 +188,7 @@ func (a Analyzer) collectPortSendersInReceivers(
 
 		// Chained receiver: chain head is the receiver for outer senders.
 		if receiver.ChainedConnection != nil {
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for _, chainHead := range receiver.ChainedConnection.Senders {
 				if chainHead.PortAddr != nil &&
 					chainHead.PortAddr.Node == nodeName &&
@@ -211,7 +211,7 @@ func (a Analyzer) collectPortSendersInReceivers(
 
 // isUnionNode identifies the builtin Union<T> node used for wrapping tags/payloads.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a Analyzer) isUnionNode(node src.Node) bool {
 	return node.EntityRef.Name == "Union" && (node.EntityRef.Pkg == "" || node.EntityRef.Pkg == "builtin")
 }
@@ -219,9 +219,9 @@ func (a Analyzer) isUnionNode(node src.Node) bool {
 // resolveUnionConstSender extracts a union literal from a sender.
 // Valid senders are union literal constants or references to constants that resolve to union literals.
 func (a Analyzer) resolveUnionConstSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (*src.UnionLiteral, *compiler.Error) {
 	if sender.Const == nil {
@@ -249,7 +249,7 @@ func (a Analyzer) resolveUnionConstSender(
 // It returns the fully analyzed union type expression or an error if the reference isn't a union.
 func (a Analyzer) resolveUnionTypeFromLiteral(
 	unionLiteral *src.UnionLiteral,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (ts.Expr, *compiler.Error) {
 	typeDef, _, err := scope.GetType(unionLiteral.EntityRef)

--- a/internal/compiler/analyzer/utils.go
+++ b/internal/compiler/analyzer/utils.go
@@ -8,7 +8,7 @@ import (
 
 type netNodesUsage map[string]netNodeUsage
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (n netNodesUsage) trackInportUsage(addr src.PortAddr) error {
 	if _, ok := n[addr.Node]; !ok {
 		n[addr.Node] = netNodeUsage{
@@ -19,7 +19,7 @@ func (n netNodesUsage) trackInportUsage(addr src.PortAddr) error {
 	return n[addr.Node].trackInportUsage(addr)
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (n netNodesUsage) trackOutportUsage(addr src.PortAddr) error {
 	if _, ok := n[addr.Node]; !ok {
 		n[addr.Node] = netNodeUsage{
@@ -34,12 +34,12 @@ type netNodeUsage struct {
 	In, Out portsUsage
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (n netNodeUsage) trackOutportUsage(addr src.PortAddr) error {
 	return n.Out.trackSlotUsage(addr)
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (n netNodeUsage) trackInportUsage(addr src.PortAddr) error {
 	return n.In.trackSlotUsage(addr)
 }
@@ -47,7 +47,7 @@ func (n netNodeUsage) trackInportUsage(addr src.PortAddr) error {
 // portsUsage maps port name to slots used, slots map is nil for single ports
 type portsUsage map[string]map[uint8]struct{}
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (p portsUsage) trackSlotUsage(addr src.PortAddr) error {
 	isArrayBypass := src.IsArrayBypassIdx(addr.Idx)
 	if _, ok := p[addr.Port]; !ok {

--- a/internal/compiler/backend/golang/backend.go
+++ b/internal/compiler/backend/golang/backend.go
@@ -53,7 +53,7 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 
 	tmpl, err := template.New("tpl.go").Funcs(funcmap).Parse(mainGoTemplate)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -83,16 +83,16 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 		files["runtime/debug_validation.go"] = []byte(debugValidationGoTemplate)
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return pkgos.SaveFilesToDir(dst, files)
 }
 
 //nolint:gocyclo // Export emission spans multiple steps; refactor later.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error { //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error { //nolint:cyclop,funlen,gocognit,lll
 	exportList := make([]exportTemplateData, 0, len(exports))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, export := range exports {
 		prog := export.Program
 		prog.Connections = ir.GraphReduction(prog.Connections)
@@ -177,16 +177,16 @@ func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace
 			case "int":
 				return fmt.Sprintf("int(%s.Int())", msgVar)
 			case "string":
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Sprintf("%s.Str()", msgVar)
 			case "[]byte":
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Sprintf("%s.Bytes()", msgVar)
 			case "bool":
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Sprintf("%s.Bool()", msgVar)
 			case "float64":
-				//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:perfsprint
 				return fmt.Sprintf("%s.Float()", msgVar)
 			default:
 				return msgVar
@@ -214,7 +214,7 @@ func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace
 
 	tmpl, err := template.New("exports.go").Funcs(funcmap).Parse(libraryGoTemplate)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -247,14 +247,14 @@ func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace
 		}
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return pkgos.SaveFilesToDir(dst, files)
 }
 
-//nolint:cyclop,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocyclo
 func (b Backend) mapFields(ports map[string]ast.Port) []fieldTemplateData {
 	fields := make([]fieldTemplateData, 0, len(ports))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for name, port := range ports {
 		goType := "runtime.Msg" // Default to runtime.Msg interface for complex types
 		if port.TypeExpr.Inst != nil {
@@ -303,7 +303,7 @@ func Title(s string) string {
 	return string(r)
 }
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (b Backend) buildFuncCalls(
 	funcs []ir.FuncCall,
 	addrToChanVar map[ir.PortAddr]string,
@@ -439,7 +439,7 @@ func (b Backend) buildFuncCalls(
 	return result, nil
 }
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 	switch msg.Type {
 	case ir.MsgTypeBool:
@@ -463,7 +463,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 		return fmt.Sprintf("runtime.NewUnionMsg(%q, %s)", msg.Union.Tag, payload), nil
 	case ir.MsgTypeList:
 		elements := make([]string, len(msg.List))
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for i, v := range msg.List {
 			el, err := b.getMessageString(&v)
 			if err != nil {
@@ -474,7 +474,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 		return fmt.Sprintf("runtime.NewListMsg([]runtime.Msg{%s})", strings.Join(elements, ", ")), nil
 	case ir.MsgTypeDict:
 		keyValuePairs := make([]string, 0, len(msg.DictOrStruct))
-		//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic,varnamelen
 		for k, v := range msg.DictOrStruct {
 			value := v
 			el, err := b.getMessageString(&value)
@@ -486,7 +486,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 		return fmt.Sprintf("runtime.NewDictMsg(map[string]runtime.Msg{%s})", strings.Join(keyValuePairs, ", ")), nil
 	case ir.MsgTypeStruct:
 		fields := make([]string, 0, len(msg.DictOrStruct))
-		//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic,varnamelen
 		for k, v := range msg.DictOrStruct {
 			value := v
 			el, err := b.getMessageString(&value)
@@ -501,7 +501,7 @@ func (b Backend) getMessageString(msg *ir.Message) (string, error) {
 }
 
 func (b Backend) insertRuntimeFiles(files map[string][]byte, replacements map[string]string) error {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return fs.WalkDir(
 		internal.Efs,
 		"runtime",
@@ -514,10 +514,10 @@ func (b Backend) insertRuntimeFiles(files map[string][]byte, replacements map[st
 				return nil
 			}
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			bb, err := internal.Efs.ReadFile(path)
 			if err != nil {
-				//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:wrapcheck
 				return err
 			}
 
@@ -555,7 +555,7 @@ func (b Backend) buildPortChanMap(connections map[ir.PortAddr]ir.PortAddr) (map[
 }
 
 func (b Backend) chanVarNameFromPortAddr(addr ir.PortAddr) string {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var s string
 	if addr.IsArray {
 		s = fmt.Sprintf("%s_%s_%d", addr.Path, addr.Port, addr.Idx)

--- a/internal/compiler/backend/golang/native/backend.go
+++ b/internal/compiler/backend/golang/native/backend.go
@@ -38,7 +38,7 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 }
 
 func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error {
-	//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:perfsprint
 	return fmt.Errorf("library mode not implemented for native backend")
 }
 
@@ -49,7 +49,7 @@ func (b Backend) buildExecutable(gomodule, output string) error {
 	}
 
 	// #nosec G204 -- command args are constructed internally from known values
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	cmd := exec.Command(
 		"go",
 		golang.ReleaseBuildArgs(filepath.Join(output, fileName), ".")...,
@@ -58,7 +58,7 @@ func (b Backend) buildExecutable(gomodule, output string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return cmd.Run()
 }
 

--- a/internal/compiler/backend/golang/wasm/backend.go
+++ b/internal/compiler/backend/golang/wasm/backend.go
@@ -19,29 +19,29 @@ type Backend struct {
 func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error {
 	tmpGoProj := dst + "/tmp"
 	if err := b.golang.EmitExecutable(tmpGoProj, prog, trace); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	if err := buildWASM(tmpGoProj, dst); err != nil {
 		return err
 	}
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return os.RemoveAll(tmpGoProj)
 }
 
 func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error {
-	//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:perfsprint
 	return fmt.Errorf("library mode not implemented for wasm backend")
 }
 
 func buildWASM(src, dst string) error {
 	outputPath := filepath.Join(dst, "output")
 	if err := os.Chdir(src); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	// #nosec G204 -- command args are constructed internally from known values
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	cmd := exec.Command(
 		"go",
 		golang.ReleaseBuildArgs(outputPath+".wasm", src)...,
@@ -49,7 +49,7 @@ func buildWASM(src, dst string) error {
 	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return cmd.Run()
 }
 

--- a/internal/compiler/backend/ir/backend.go
+++ b/internal/compiler/backend/ir/backend.go
@@ -35,7 +35,7 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 }
 
 func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error {
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, export := range exports {
 		if err := b.emit(dst, "ir_"+export.Name, export.Program); err != nil {
 			return err
@@ -74,14 +74,14 @@ func (b Backend) emit(dst, name string, prog *ir.Program) error {
 		return fmt.Errorf("unknown format: %s", b.format)
 	}
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	f, err := os.OpenFile(
 		filepath.Join(dst, fileName),
 		os.O_CREATE|os.O_TRUNC|os.O_RDWR,
 		0755,
 	)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	defer f.Close()

--- a/internal/compiler/backend/ir/dot/graphviz.go
+++ b/internal/compiler/backend/ir/dot/graphviz.go
@@ -99,14 +99,14 @@ func (c *Cluster) getOrCreateClusterNode(b *ClusterBuilder, path string) *Node {
 	return c.getOrCreateClusterNodeRec(b, path, "", path)
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (c *Cluster) getOrCreateClusterNodeRec(b *ClusterBuilder, path, prefix, remaining string) *Node {
 	before, after, found := strings.Cut(remaining, "/")
 	if !found {
 		if c.Nodes == nil {
 			c.Nodes = map[string]*Node{}
 		}
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		n, ok := c.Nodes[before]
 		if ok {
 			return n
@@ -161,7 +161,7 @@ func (b *ClusterBuilder) insertClusterNode(addr ir.PortAddr) {
 		b.Main = cluster
 		b.nextId++
 	}
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	switch n := b.Main.getOrCreateClusterNode(b, addr.Path); {
 	case strings.HasSuffix(addr.Path, "/in"):
 		if n.In == nil {
@@ -186,6 +186,6 @@ func (b *ClusterBuilder) Build(w io.Writer) error {
 	if b.once.Do(b.initTemplates); b.err != nil {
 		return b.err
 	}
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return b.tmpl.ExecuteTemplate(w, "graph.dot.tmpl", b)
 }

--- a/internal/compiler/backend/ir/mermaid/backend.go
+++ b/internal/compiler/backend/ir/mermaid/backend.go
@@ -1,4 +1,4 @@
-//nolint:cyclop // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop
 package mermaid
 
 import (
@@ -15,9 +15,9 @@ import (
 type Encoder struct{}
 
 //nolint:gocyclo // Encoding includes multiple rendering branches.
-//nolint:cyclop,funlen,gocognit,maintidx,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:funlen,gocognit,maintidx,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,gocognit,lll,maintidx,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx,varnamelen
+//nolint:funlen,gocognit,maintidx,varnamelen
+func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,gocognit,lll,maintidx,varnamelen
 	// Parse comment for metadata (module, compiler version)
 	// Format: // module=@@ main=hello_world compiler=0.34.0
 	var modName, compilerVer string
@@ -43,7 +43,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 	fmt.Fprintln(w, "```mermaid")
 
 	if _, err := fmt.Fprintln(w, "flowchart TD"); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -54,7 +54,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
     classDef invisible display:none;
 `
 	if _, err := fmt.Fprint(w, styles); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -105,7 +105,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 		// Default label is the last part of the path
 		parts := strings.Split(path, "/")
 		label := parts[len(parts)-1]
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		n := &NodeInfo{
 			Path:  path,
 			Label: label,
@@ -149,7 +149,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 
 	// Second pass: Extract metadata from prog.Funcs
 	// Iterate over Funcs and match them to existing nodes by looking at their used ports.
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for _, f := range prog.Funcs {
 		var matchPath string
 
@@ -186,7 +186,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 
 		// If we found a path, update the node's metadata
 		if matchPath != "" {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			if n, ok := nodes[matchPath]; ok {
 				n.Meta.Ref = f.Ref
 				if f.Msg != nil {
@@ -195,10 +195,10 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 					case ir.MsgTypeString:
 						n.Meta.Msg = fmt.Sprintf("%q", f.Msg.String)
 					case ir.MsgTypeInt:
-						//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+						//nolint:perfsprint
 						n.Meta.Msg = fmt.Sprintf("%d", f.Msg.Int)
 					case ir.MsgTypeBool:
-						//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+						//nolint:perfsprint
 						n.Meta.Msg = fmt.Sprintf("%v", f.Msg.Bool)
 					case ir.MsgTypeFloat:
 						n.Meta.Msg = fmt.Sprintf("%f", f.Msg.Float)
@@ -223,7 +223,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 
 	// 2. Emit Nodes (Subgraphs)
 	for _, path := range nodePaths {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		n := nodes[path]
 		if n == nil {
 			panic("internal invariant violated: node map contains nil entry")
@@ -280,7 +280,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 	for s, r := range prog.Connections {
 		conns = append(conns, conn{s, r})
 	}
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	sort.Slice(conns, func(i, j int) bool {
 		s1 := conns[i].From.String()
 		s2 := conns[j].From.String()
@@ -303,7 +303,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 	fmt.Fprintln(w, "| Node | Ref | Config | Ports |")
 	fmt.Fprintln(w, "| :--- | :--- | :--- | :--- |")
 	for _, path := range nodePaths {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		n := nodes[path]
 		if n == nil {
 			panic("internal invariant violated: node map contains nil entry")
@@ -344,7 +344,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error { //nolint:funlen,g
 	return nil
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func sanitize(s string) string {
 	return strings.NewReplacer(
 		"/", "_",

--- a/internal/compiler/backend/ir/threejs/backend.go
+++ b/internal/compiler/backend/ir/threejs/backend.go
@@ -1,4 +1,4 @@
-//nolint:cyclop // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop
 package threejs
 
 import (
@@ -14,11 +14,11 @@ import (
 
 type Encoder struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 	tmpl, err := template.New("threejs").Parse(templateHTML)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -27,7 +27,7 @@ func (e Encoder) Encode(w io.Writer, prog *ir.Program) error {
 		return err
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return tmpl.Execute(w, data)
 }
 
@@ -65,9 +65,9 @@ type outgoingConn struct {
 }
 
 //nolint:gocyclo // Data prep enumerates many node/conn cases.
-//nolint:cyclop,funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:funlen,gocognit,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocognit,lll,maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,maintidx
+//nolint:funlen,gocognit,maintidx
+func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocognit,lll,maintidx
 	nodes := make(map[string]nodeData)
 	pathMap := make(map[string]string) // Maps a port's path to the unified node name
 
@@ -82,7 +82,7 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 	}
 
 	// 1. Collect all nodes defined in Funcs
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for _, f := range prog.Funcs {
 		// Determine the node name for this function call
 		name := ""
@@ -112,7 +112,7 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 
 		// Map all paths involved in this func to the unified name
 		// and populate ports
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for j, port := range f.IO.In {
 			pathMap[port.Path] = name
 
@@ -127,7 +127,7 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 			}
 		}
 
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for j, port := range f.IO.Out {
 			pathMap[port.Path] = name
 
@@ -153,10 +153,10 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 	parentToChildren := make(map[string][]outgoingConn)
 
 	connections := make([]connectionData, 0, len(prog.Connections))
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for from, to := range prog.Connections {
 		// Resolve From Node
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		fromNode, ok := pathMap[from.Path]
 		if !ok {
 			fromNode = getNodeName(from.Path)
@@ -310,7 +310,7 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 	// We will store computed X for nodes to use for next rank
 	nodeX := make(map[string]float64)
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for r := 0; r <= maxRank; r++ {
 		rankNodes := nodesByRank[r]
 
@@ -333,7 +333,7 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 			sort.Strings(rankNodes)
 		}
 
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for i, nodeName := range rankNodes {
 			node := nodes[nodeName]
 			// Invert Y so rank 0 is at top
@@ -360,13 +360,13 @@ func prepareData(prog *ir.Program) (templateData, error) { //nolint:funlen,gocog
 
 	nodesJSON, err := json.Marshal(nodes)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return templateData{}, err
 	}
 
 	connsJSON, err := json.Marshal(connections)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return templateData{}, err
 	}
 
@@ -382,7 +382,7 @@ func getParentWeight(childNode string, nodeX map[string]float64, parentToChildre
 	count := 0.0
 
 	for parent, conns := range parentToChildren {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		if pX, ok := nodeX[parent]; ok {
 			for _, conn := range conns {
 				if conn.targetNode == childNode {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -37,14 +37,14 @@ type CompilerOutput struct {
 	FrontEnd FrontendResult
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (c Compiler) Compile(ctx context.Context, input CompilerInput) (*CompilerOutput, error) {
 	feResult, err := c.fe.Process(ctx, input.MainPkgPath)
 	if err != nil {
 		return nil, errors.New(err.Error()) // to avoid non-nil interface go-issue
 	}
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if input.Mode == ModeLibrary {
 		exports, err := c.me.ProcessLibrary(feResult)
 		if err != nil {
@@ -55,7 +55,7 @@ func (c Compiler) Compile(ctx context.Context, input CompilerInput) (*CompilerOu
 			exports,
 			input.EmitTraceFile,
 		); err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return nil, err
 		}
 	} else {
@@ -68,7 +68,7 @@ func (c Compiler) Compile(ctx context.Context, input CompilerInput) (*CompilerOu
 			prog,
 			input.EmitTraceFile,
 		); err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return nil, err
 		}
 	}
@@ -138,7 +138,7 @@ type Middleend struct {
 	irgen     Irgen
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (m Middleend) ProcessExecutable(feResult FrontendResult) (*ir.Program, *Error) {
 	analyzedBuild, err := m.analyzer.Analyze(
 		feResult.ParsedBuild,
@@ -175,7 +175,7 @@ func (m Middleend) ProcessExecutable(feResult FrontendResult) (*ir.Program, *Err
 	return irProg, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (m Middleend) ProcessLibrary(feResult FrontendResult) ([]LibraryExport, *Error) {
 	// Library analysis (empty main package)
 	analyzedBuild, err := m.analyzer.Analyze(
@@ -203,7 +203,7 @@ func (m Middleend) ProcessLibrary(feResult FrontendResult) ([]LibraryExport, *Er
 	pkg, ok := entryMod.Packages[feResult.MainPkg]
 	if !ok {
 		return nil, &Error{
-			//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:perfsprint
 			Message: fmt.Sprintf("package not found: %s", feResult.MainPkg),
 		}
 	}
@@ -211,13 +211,13 @@ func (m Middleend) ProcessLibrary(feResult FrontendResult) ([]LibraryExport, *Er
 	interopableExports := pkg.GetInteropableComponents()
 	if len(interopableExports) == 0 {
 		return nil, &Error{
-			//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:perfsprint
 			Message: fmt.Sprintf("no interopable exports found in %s", feResult.MainPkg),
 		}
 	}
 
 	result := make([]LibraryExport, 0, len(interopableExports))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, export := range interopableExports {
 		prog, err := m.irgen.GenerateForComponent(desugaredBuild, feResult.MainPkg, export.Name)
 		if err != nil {

--- a/internal/compiler/desugarer/component.go
+++ b/internal/compiler/desugarer/component.go
@@ -13,9 +13,9 @@ type handleComponentResult struct {
 }
 
 func (d *Desugarer) desugarComponent(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	component src.Component,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (handleComponentResult, error) {
 	if len(component.Net) == 0 && len(component.Nodes) == 0 {
@@ -49,7 +49,7 @@ func (d *Desugarer) desugarComponent(
 	desugaredNetwork := slices.Clone(desugarNetResult.desugaredConnections)
 
 	// add virtual constants created by network handler to virtual entities
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for name, constant := range desugarNetResult.constsToInsert {
 		virtualEntities[name] = src.Entity{
 			Kind:  src.ConstEntity,
@@ -85,16 +85,16 @@ func (d *Desugarer) desugarComponent(
 }
 
 func (d *Desugarer) desugarNodes(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	component src.Component,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	virtualEntities map[string]src.Entity,
 ) (map[string]src.Node, []src.Connection, error) {
 	desugaredNodes := make(map[string]src.Node, len(component.Nodes))
 	virtualConns := []src.Connection{}
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, node := range component.Nodes {
 		extraConns, err := d.handleNode(
 			scope,

--- a/internal/compiler/desugarer/const.go
+++ b/internal/compiler/desugarer/const.go
@@ -6,7 +6,7 @@ import (
 
 // handleConst handles case when constant has integer value and type is float.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (d *Desugarer) handleConst(constant src.Const) src.Const {
 	if constant.Value.Message == nil {
 		return constant

--- a/internal/compiler/desugarer/del.go
+++ b/internal/compiler/desugarer/del.go
@@ -13,7 +13,7 @@ type unusedOutportsResult struct {
 
 func (Desugarer) handleUnusedOutports(
 	unusedOutports nodeOutportsUsed,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	meta core.Meta,
 ) unusedOutportsResult {
 	destructorNodeName := "__del__"
@@ -67,17 +67,17 @@ func (Desugarer) handleUnusedOutports(
 	return result
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (Desugarer) findUnusedOutports(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	component src.Component,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	usedNodePorts nodeOutportsUsed,
 ) nodeOutportsUsed {
 	unusedOutports := newNodePortsMap()
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for nodeName, node := range component.Nodes {
 		entity, _, err := scope.Entity(node.EntityRef)
 		if err != nil {
@@ -87,7 +87,7 @@ func (Desugarer) findUnusedOutports(
 			continue
 		}
 
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		var io src.IO
 		if entity.Kind == src.InterfaceEntity {
 			io = entity.Interface.IO

--- a/internal/compiler/desugarer/desugarer.go
+++ b/internal/compiler/desugarer/desugarer.go
@@ -11,7 +11,7 @@ import (
 
 // Desugarer is NOT thread safe and must be used in single thread
 //
-//nolint:recvcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:recvcheck
 type Desugarer struct {
 	virtualSelectorsCount uint64
 	virtualEmittersCount  uint64
@@ -128,12 +128,12 @@ func (d *Desugarer) desugarPkg(pkg src.Package, scope Scope) (src.Package, error
 // desugarFile injects import of std/builtin into every pkg's file and desugares it's every entity
 func (d *Desugarer) desugarFile(
 	file src.File,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (src.File, error) {
 	desugaredEntities := make(map[string]src.Entity, len(file.Entities))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for entityName, entity := range file.Entities {
 		entityResult, err := d.desugarEntity(entity, scope)
 		if err != nil {
@@ -172,9 +172,9 @@ type desugarEntityResult struct {
 }
 
 func (d *Desugarer) desugarEntity(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	entity src.Entity,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 ) (desugarEntityResult, error) {
 	if entity.Kind != src.ComponentEntity && entity.Kind != src.ConstEntity {
@@ -195,7 +195,7 @@ func (d *Desugarer) desugarEntity(
 	desugaredVersions := make([]src.Component, 0, len(entity.Component))
 	entitiesToInsert := make(map[string]src.Entity)
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, component := range entity.Component {
 		componentResult, err := d.desugarComponent(component, scope)
 		if err != nil {

--- a/internal/compiler/desugarer/network.go
+++ b/internal/compiler/desugarer/network.go
@@ -20,7 +20,7 @@ type handleNetworkResult struct {
 }
 
 func (d *Desugarer) desugarNetwork(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	net []src.Connection,
 	nodes map[string]src.Node,
@@ -82,7 +82,7 @@ func (d *Desugarer) mergeImplicitFanIn(
 	positions := map[receiverKey]int{}
 	kept := make([]src.Connection, 0, len(net))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		if isArrayBypassConn(conn) {
 			kept = append(kept, conn)
@@ -142,7 +142,7 @@ func (d *Desugarer) mergeImplicitFanIn(
 }
 
 func (d *Desugarer) desugarConnections(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
 	net []src.Connection,
 	nodePortsUsed nodeOutportsUsed,
@@ -153,7 +153,7 @@ func (d *Desugarer) desugarConnections(
 ) ([]src.Connection, error) {
 	desugaredConnections := make([]src.Connection, 0, len(net))
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range net {
 		result, err := d.desugarConnection(
 			iface,
@@ -183,13 +183,13 @@ type desugarConnectionResult struct {
 	insert  []src.Connection
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func isArrayBypassConn(conn src.Connection) bool {
 	_, _, ok := arrayBypassPorts(conn)
 	return ok
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func arrayBypassPorts(conn src.Connection) (*src.PortAddr, *src.PortAddr, bool) {
 	if len(conn.Senders) != 1 || len(conn.Receivers) != 1 {
 		return nil, nil, false
@@ -210,9 +210,9 @@ func arrayBypassPorts(conn src.Connection) (*src.PortAddr, *src.PortAddr, bool) 
 }
 
 func (d *Desugarer) desugarConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection,
 	nodePortsUsed nodeOutportsUsed,
 	scope Scope,
@@ -244,9 +244,9 @@ func (d *Desugarer) desugarConnection(
 }
 
 func (d *Desugarer) desugarNormalConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 	nodePortsUsed nodeOutportsUsed,
 	scope Scope,
@@ -334,9 +334,9 @@ type desugarReceiverResult struct {
 
 // desugarSingleReceiver expects connection without fan-out (it must be desugared before).
 func (d *Desugarer) desugarSingleReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 	scope Scope,
 	nodes map[string]src.Node,
@@ -408,18 +408,18 @@ func (d *Desugarer) desugarSingleReceiver(
 	}, nil
 }
 
-//nolint:funlen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:funlen
 func (d *Desugarer) desugarChainedConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiver src.ConnectionReceiver,
 	scope Scope,
 	nodes map[string]src.Node,
 	nodePortsUsed nodeOutportsUsed,
 	nodesToInsert map[string]src.Node,
 	constsToInsert map[string]src.Const,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 ) (desugarConnectionResult, error) {
 	chainedConn := *receiver.ChainedConnection
@@ -447,7 +447,7 @@ func (d *Desugarer) desugarChainedConnection(
 
 	locOnlyMeta := core.Meta{Location: chainHead.Meta.Location}
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if chainHead.Const != nil {
 		d.virtualTriggersCount++
 		triggerNodeName := fmt.Sprintf("__newv2__%d", d.virtualTriggersCount)
@@ -556,11 +556,11 @@ type desugarSenderResult struct {
 
 // desugarSingleSender keeps receiver side untouched so it must be desugared by caller (except for selectors).
 //
-//nolint:funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:funlen,gocognit
 func (d *Desugarer) desugarSingleSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 	scope Scope,
 	nodes map[string]src.Node,
@@ -629,7 +629,7 @@ func (d *Desugarer) desugarSingleSender(
 		}, nil
 	}
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if sender.Const != nil {
 		if sender.Const.Value.Ref != nil {
 			portAddr, err := d.handleConstRefSender(*sender.Const.Value.Ref, nodesToInsert, scope)
@@ -674,12 +674,12 @@ func (d *Desugarer) desugarSingleSender(
 func (d *Desugarer) getFirstInportName(
 	scope Scope,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 ) (string, error) {
 	io, err := scope.GetNodeIOByPortAddr(nodes, portAddr)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", err
 	}
 	for inport := range io.In {
@@ -691,13 +691,13 @@ func (d *Desugarer) getFirstInportName(
 func (d *Desugarer) getFirstOutportName(
 	scope Scope,
 	nodes map[string]src.Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr src.PortAddr,
 ) (string, error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io, err := scope.GetNodeIOByPortAddr(nodes, portAddr)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", err
 	}
 
@@ -720,7 +720,7 @@ func newComponentRef() core.EntityRef {
 }
 
 func (d *Desugarer) handleLiteralSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	constant src.Const,
 	nodesToInsert map[string]src.Node,
 	constsToInsert map[string]src.Const,
@@ -761,7 +761,7 @@ func (d *Desugarer) handleLiteralSender(
 }
 
 func (d *Desugarer) handleConstRefSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	ref core.EntityRef,
 	nodesToInsert map[string]src.Node,
 	scope Scope,
@@ -803,7 +803,7 @@ func (d *Desugarer) handleConstRefSender(
 
 // getConstTypeByRef is needed to figure out type parameters for Const node
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (d *Desugarer) getConstTypeByRef(ref core.EntityRef, scope Scope) (ts.Expr, error) {
 	entity, _, err := scope.Entity(ref)
 	if err != nil {
@@ -831,9 +831,9 @@ type desugarFanOutResult struct {
 }
 
 func (d *Desugarer) desugarFanOut(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 	nodesToInsert map[string]src.Node,
 	constsToInsert map[string]src.Const,
@@ -865,7 +865,7 @@ func (d *Desugarer) desugarFanOut(
 	}
 
 	insert := make([]src.Connection, 0, len(normConn.Receivers))
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	for i, receiver := range normConn.Receivers {
 		if i > maxUint8 {
 			return desugarFanOutResult{}, fmt.Errorf("fan-out index %d overflows uint8", i)
@@ -917,9 +917,9 @@ func (d *Desugarer) desugarFanOut(
 // desugarFanIn returns connections that must be used instead of given one.
 // It recursevely desugars each connection before return so result is final.
 func (d *Desugarer) desugarFanIn(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	iface src.Interface,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	normConn src.Connection,
 	nodesToInsert map[string]src.Node,
 	constsToInsert map[string]src.Const,
@@ -943,7 +943,7 @@ func (d *Desugarer) desugarFanIn(
 
 	// 2. connect each sender of this connection with fan-in node
 	desugaredFanIn := make([]src.Connection, 0, len(normConn.Senders))
-	//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic,varnamelen
 	for i, originalSender := range normConn.Senders {
 		if i > maxUint8 {
 			return nil, fmt.Errorf("fan-in index %d overflows uint8", i)

--- a/internal/compiler/desugarer/network_test.go
+++ b/internal/compiler/desugarer/network_test.go
@@ -15,7 +15,7 @@ import (
 // Note: some cases are hard to test this way because desugarer depends on Scope object
 // which is normally passed from top-level functions in this package.
 //
-//nolint:maintidx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:maintidx
 func TestDesugarNetwork(t *testing.T) {
 	tests := []struct {
 		mockScope      func(scope *MockScopeMockRecorder)
@@ -86,7 +86,7 @@ func TestDesugarNetwork(t *testing.T) {
 				"node2": {EntityRef: core.EntityRef{Pkg: "test", Name: "Node2"}},
 				"node3": {EntityRef: core.EntityRef{Pkg: "test", Name: "Node3"}},
 			},
-			//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:dupl
 			expectedResult: handleNetworkResult{
 				desugaredConnections: []src.Connection{
 					{
@@ -163,7 +163,7 @@ func TestDesugarNetwork(t *testing.T) {
 				"node1": {EntityRef: core.EntityRef{Pkg: "test", Name: "Node1"}},
 				"node2": {EntityRef: core.EntityRef{Pkg: "test", Name: "Node2"}},
 			},
-			//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:dupl
 			expectedResult: handleNetworkResult{
 				desugaredConnections: []src.Connection{
 					{

--- a/internal/compiler/desugarer/node.go
+++ b/internal/compiler/desugarer/node.go
@@ -9,11 +9,11 @@ import (
 	"github.com/nevalang/neva/pkg/core"
 )
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (Desugarer) handleNode(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	node src.Node,
 	desugaredNodes map[string]src.Node,
 	nodeName string,
@@ -86,7 +86,7 @@ func (Desugarer) handleNode(
 	if hasAnonDep { // this node has anonymous dependency injected
 		// find name of the dependency in this node's sub-nodes
 		var depName string
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for depParamName, depParam := range version.Nodes {
 			kind, err := scope.GetEntityKind(depParam.EntityRef)
 			if err != nil {
@@ -137,7 +137,7 @@ func (Desugarer) handleNode(
 
 	// first, we need to create ports for our virtual component
 	inports := make(map[string]src.Port, len(structFields))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for fieldName, fieldTypeExpr := range structFields {
 		inports[fieldName] = src.Port{
 			TypeExpr: fieldTypeExpr,

--- a/internal/compiler/desugarer/struct_selectors.go
+++ b/internal/compiler/desugarer/struct_selectors.go
@@ -16,7 +16,7 @@ type desugarStructSelectorsResult struct {
 // desugarStructSelectors doesn't generate incoming connections for field node,
 // it's responsibility of desugarChainConnection.
 func (d *Desugarer) desugarStructSelectors(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection, // sender here is selector (this is chained connection)
 	nodesToInsert map[string]src.Node,
 	constsToInsert map[string]src.Const,
@@ -82,7 +82,7 @@ func pathConstTypeExpr() ts.Expr {
 	}
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Desugarer) createSelectorCfgMsg(senderSide src.ConnectionSender) src.Const {
 	result := make([]src.ConstValue, 0, len(senderSide.StructSelector))
 	locOnlyMeta := core.Meta{

--- a/internal/compiler/error.go
+++ b/internal/compiler/error.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nevalang/neva/pkg/core"
 )
 
-//nolint:recvcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:recvcheck
 type Error struct {
 	Meta    *core.Meta
 	child   *Error
@@ -26,7 +26,7 @@ func (e Error) Unwrap() *Error {
 }
 
 func (e *Error) Error() string {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var s string
 
 	current := e.Unwrap()

--- a/internal/compiler/ir/graph_reduction.go
+++ b/internal/compiler/ir/graph_reduction.go
@@ -36,7 +36,7 @@ func GraphReduction(connections map[PortAddr]PortAddr) map[PortAddr]PortAddr {
 // getFinalReceiver returns the final receiver for a given port address.
 // It also returns true if the given port address was intermediate, false otherwise.
 //
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func getFinalReceiver(
 	receiver PortAddr,
 	connections map[PortAddr]PortAddr,

--- a/internal/compiler/ir/ir.go
+++ b/internal/compiler/ir/ir.go
@@ -23,7 +23,7 @@ func (p Program) MarshalJSON() ([]byte, error) {
 		connections[from.String()] = to.String()
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return json.Marshal(struct {
 		Connections map[string]string `json:"connections,omitempty"`
 		programAlias
@@ -75,7 +75,7 @@ func (p PortAddr) String() string {
 }
 
 func (p PortAddr) MarshalJSON() ([]byte, error) {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return json.Marshal(p.String())
 }
 

--- a/internal/compiler/irgen/func.go
+++ b/internal/compiler/irgen/func.go
@@ -8,7 +8,7 @@ import (
 	src "github.com/nevalang/neva/pkg/ast"
 )
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Generator) getFuncRef(versions []src.Component, node src.Node) (string, src.Component) {
 	var version src.Component
 	if len(versions) == 1 {
@@ -25,7 +25,7 @@ func (Generator) getFuncRef(versions []src.Component, node src.Node) (string, sr
 	return externArg, version
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func getConfigMsg(node src.Node, scope src.Scope) (*ir.Message, error) {
 	bindArg, hasBind := node.Directives[compiler.BindDirective]
 	if !hasBind {
@@ -35,13 +35,13 @@ func getConfigMsg(node src.Node, scope src.Scope) (*ir.Message, error) {
 
 	entityRef, err := compiler.ParseEntityRef(context.Background(), bindArg)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	entity, location, err := scope.Entity(entityRef)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/compiler/irgen/irgen.go
+++ b/internal/compiler/irgen/irgen.go
@@ -59,7 +59,7 @@ func (g Generator) GenerateForComponent(
 		Name: componentName,
 	})
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -120,11 +120,11 @@ func buildProgramComment(modulePath, moduleVersion, mainPackage string) string {
 	)
 }
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (g Generator) processNode(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
 	result *ir.Program,
 ) {
@@ -167,7 +167,7 @@ func (g Generator) processNode(
 		result,
 	)
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for subnodeName, subnode := range version.Nodes {
 		nodePortsUsage, ok := subnodesPortsUsage[subnodeName]
 		if !ok {
@@ -180,12 +180,12 @@ func (g Generator) processNode(
 		// our component is used like this `Parent{handler FilterOdd<T>}`
 		// Parent.handler is not interface, but its component has interface
 		// It needs our DI nodes, so we merge our DI with node's DI
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if len(nodeCtx.node.DIArgs) > 0 {
 			if subnode.DIArgs == nil {
 				subnode.DIArgs = make(map[string]src.Node)
 			}
-			//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic,varnamelen
 			for k, ourDIarg := range nodeCtx.node.DIArgs {
 				// FIXME HOC with drilled di arg can't resolve ref to it
 				// because it resolves it with its own location
@@ -241,7 +241,7 @@ func (g Generator) processNode(
 	}
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Generator) insertAndReturnInports(nodeCtx nodeContext) []ir.PortAddr {
 	inports := make([]ir.PortAddr, 0, len(nodeCtx.portsUsage.in))
 
@@ -264,7 +264,7 @@ func (Generator) insertAndReturnInports(nodeCtx nodeContext) []ir.PortAddr {
 	return inports
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Generator) insertAndReturnOutports(nodeCtx nodeContext) []ir.PortAddr {
 	outports := make([]ir.PortAddr, 0, len(nodeCtx.portsUsage.out))
 

--- a/internal/compiler/irgen/message.go
+++ b/internal/compiler/irgen/message.go
@@ -9,13 +9,13 @@ import (
 	src "github.com/nevalang/neva/pkg/ast"
 )
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func getIRMsgBySrcRef(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	constant src.ConstValue,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	scope src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	typeExpr ts.Expr,
 ) (*ir.Message, error) {
 	if constant.Ref != nil {
@@ -67,7 +67,7 @@ func getIRMsgBySrcRef(
 		listElType := typeExpr.Inst.Args[0]
 		listMsg := make([]ir.Message, len(constant.Message.List))
 
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for i, el := range constant.Message.List {
 			result, err := getIRMsgBySrcRef(el, scope, listElType)
 			if err != nil {
@@ -81,12 +81,12 @@ func getIRMsgBySrcRef(
 			List: listMsg,
 		}, nil
 	case constant.Message.DictOrStruct != nil:
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		m := make(map[string]ir.Message, len(constant.Message.DictOrStruct))
 
 		isStruct := typeExpr.Lit != nil && typeExpr.Lit.Struct != nil
 
-		//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic,varnamelen
 		for name, el := range constant.Message.DictOrStruct {
 			var elType ts.Expr
 			if isStruct {

--- a/internal/compiler/irgen/network.go
+++ b/internal/compiler/irgen/network.go
@@ -13,13 +13,13 @@ import (
 func (g Generator) processNetwork(
 	conns []src.Connection,
 	scope *src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
 	result *ir.Program,
 ) map[string]portsUsage {
 	nodesPortsUsage := map[string]portsUsage{}
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, conn := range conns {
 		if sender, receiver, ok := arrayBypassPorts(conn); ok {
 			g.processArrayBypassConnection(
@@ -49,12 +49,12 @@ func (g Generator) processNetwork(
 }
 
 func (Generator) processArrayBypassConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	senderPort src.PortAddr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiverPort src.PortAddr,
 	nodesPortsUsage map[string]portsUsage,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
 	result *ir.Program,
 ) {
@@ -105,10 +105,10 @@ func (Generator) processArrayBypassConnection(
 }
 
 func (g Generator) processNormalConnection(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
 	scope *src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	conn src.Connection,
 	nodesPortsUsage map[string]portsUsage,
 	result *ir.Program,
@@ -128,7 +128,7 @@ func (g Generator) processNormalConnection(
 	result.Connections[irSenderSidePortAddr] = irReceiverPortAddr
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func arrayBypassPorts(conn src.Connection) (*src.PortAddr, *src.PortAddr, bool) {
 	if len(conn.Senders) != 1 || len(conn.Receivers) != 1 {
 		return nil, nil, false
@@ -148,10 +148,10 @@ func arrayBypassPorts(conn src.Connection) (*src.PortAddr, *src.PortAddr, bool) 
 }
 
 func (g Generator) processSender(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
 	scope *src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	sender src.ConnectionSender,
 	nodesUsage map[string]portsUsage,
 ) ir.PortAddr {
@@ -222,10 +222,10 @@ func (g Generator) processSender(
 
 // processReceiver maps src connection side to ir connection side 1-1 just making the port addr's path absolute
 func (g Generator) processReceiver(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	nodeCtx nodeContext,
 	scope *src.Scope,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	receiver src.ConnectionReceiver,
 	nodesUsage map[string]portsUsage,
 ) ir.PortAddr {
@@ -299,7 +299,7 @@ func joinNodePath(nodePath []string, nodeName string) string {
 
 // this is very important because runtime function calls depends on this order.
 func sortPortAddrs(addrs []ir.PortAddr) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	sort.Slice(addrs, func(i, j int) bool {
 		if addrs[i].Path != addrs[j].Path {
 			return addrs[i].Path < addrs[j].Path

--- a/internal/compiler/parser/listener.go
+++ b/internal/compiler/parser/listener.go
@@ -68,7 +68,7 @@ func (s *treeShapeListener) EnterInterfaceStmt(actx *generated.InterfaceStmtCont
 		panic("missing interface definition")
 	}
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	v, err := s.parseInterfaceDef(ifaceDef)
 	if err != nil {
 		panic(err)

--- a/internal/compiler/parser/listener_helpers.go
+++ b/internal/compiler/parser/listener_helpers.go
@@ -60,7 +60,7 @@ func (s *treeShapeListener) parseTypeParams(
 	typeParams := params.TypeParamList().AllTypeParam()
 	result := make([]ts.Param, 0, len(typeParams))
 	for _, typeParam := range typeParams {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		v, err := s.parseTypeExpr(typeParam.TypeExpr())
 		if err != nil {
 			return src.TypeParams{}, err
@@ -116,9 +116,9 @@ func (s *treeShapeListener) parseTypeExpr(expr generated.ITypeExprContext) (ts.E
 	}
 
 	var result *ts.Expr
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if instExpr := expr.TypeInstExpr(); instExpr != nil {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		v, err := s.parseTypeInstExpr(instExpr)
 		if err != nil {
 			return ts.Expr{}, &compiler.Error{
@@ -414,7 +414,7 @@ func (s *treeShapeListener) parsePorts(
 		arr := port.ArrayPortDef()
 
 		var (
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			id       antlr.TerminalNode
 			typeExpr generated.ITypeExprContext
 			isArr    bool
@@ -434,7 +434,7 @@ func (s *treeShapeListener) parsePorts(
 			portName = id.GetText()
 		}
 
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		v, err := s.parseTypeExpr(typeExpr)
 		if err != nil {
 			return nil, err
@@ -476,7 +476,7 @@ func (s *treeShapeListener) parseInterfaceDef(
 	if inPortsDef == nil || inPortsDef.PortsDef() == nil {
 		panic("internal invariant violated: missing in ports definition in interface")
 	}
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	in, err := s.parsePorts(inPortsDef.PortsDef().AllPortDef())
 	if err != nil {
 		return src.Interface{}, err
@@ -515,7 +515,7 @@ func (s *treeShapeListener) parseInterfaceDef(
 	}, nil
 }
 
-//nolint:funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:funlen,gocognit
 func (s *treeShapeListener) parseNodes(
 	actx generated.ICompNodesDefBodyContext,
 	isRootLevel bool,
@@ -701,7 +701,7 @@ func (s *treeShapeListener) parsePortAddr(
 
 func (s *treeShapeListener) parsePortAddrIdx(
 	idxText string,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	meta core.Meta,
 ) (*uint8, *compiler.Error) {
 	if idxText == "*" {
@@ -729,7 +729,7 @@ func (s *treeShapeListener) parsePortAddrIdx(
 func (s *treeShapeListener) parseSinglePortAddr(
 	fallbackNode string,
 	expr generated.ISinglePortAddrContext,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	meta core.Meta,
 ) (src.PortAddr, *compiler.Error) {
 	nodeName := fallbackNode
@@ -803,8 +803,8 @@ func (s *treeShapeListener) parseConstSenderLiteral(
 }
 
 //nolint:gocyclo // Parsing literals requires many grammar branches.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (s *treeShapeListener) parseMessage( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (s *treeShapeListener) parseMessage( //nolint:cyclop,funlen,gocognit,lll
 	constVal generated.IConstLitContext,
 ) (src.MsgLiteral, *compiler.Error) {
 	msg := src.MsgLiteral{
@@ -1032,7 +1032,7 @@ func (s *treeShapeListener) parseTypeDef(
 		body = &typeExpr
 	}
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	v, err := s.parseTypeParams(actx.TypeParams())
 	if err != nil {
 		return src.Entity{}, err
@@ -1242,7 +1242,7 @@ func (s *treeShapeListener) parseConnection(connDef generated.IConnDefContext) (
 
 func (s *treeShapeListener) parseConnDef(
 	actx generated.IConnDefContext,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	meta core.Meta,
 ) (src.Connection, *compiler.Error) {
 	if actx == nil {
@@ -1349,7 +1349,7 @@ func (s *treeShapeListener) parseSingleReceiverSide(
 
 func (s *treeShapeListener) parseChainedConnExpr(
 	actx generated.IChainedNormConnContext,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	connMeta core.Meta,
 ) (src.ConnectionReceiver, *compiler.Error) {
 	parsedConn, err := s.parseConnDef(actx.ConnDef(), connMeta)
@@ -1423,7 +1423,7 @@ func (s *treeShapeListener) parseMultipleReceiverSides(
 	return parsedReceivers, nil
 }
 
-//nolint:cyclop,funlen,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocyclo
 func (s *treeShapeListener) parseSingleSender(
 	senderSide generated.ISingleSenderSideContext,
 ) (src.ConnectionSender, *compiler.Error) {

--- a/internal/compiler/parser/parser.go
+++ b/internal/compiler/parser/parser.go
@@ -124,10 +124,10 @@ func (p Parser) parseFile(
 	return listener.state, nil
 }
 
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func walkTree(listener antlr.ParseTreeListener, tree antlr.ParseTree) (err *compiler.Error) {
 	defer func() {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		if e := recover(); e != nil {
 			if compilerErr, ok := e.(*compiler.Error); ok {
 				err = compilerErr

--- a/internal/compiler/typesystem/helper.go
+++ b/internal/compiler/typesystem/helper.go
@@ -8,7 +8,7 @@ type Helper struct{}
 
 // any base type def (without body) that has type parameters allows recursion
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (h Helper) BaseDefWithRecursionAllowed(params ...Param) Def {
 	return Def{
 		Params:   params,
@@ -18,12 +18,12 @@ func (h Helper) BaseDefWithRecursionAllowed(params ...Param) Def {
 
 // Do not pass empty string as a name to avoid Body.Empty() == true
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (h Helper) BaseDef(params ...Param) Def {
 	return Def{Params: params}
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (h Helper) Def(body Expr, params ...Param) Def {
 	return Def{
 		Params:   params,
@@ -33,7 +33,7 @@ func (h Helper) Def(body Expr, params ...Param) Def {
 
 // Do not pass empty string as a name to avoid inst.Empty() == true
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (h Helper) Inst(ref string, args ...Expr) Expr {
 	if args == nil {
 		args = []Expr{} // makes easier testing because resolver returns non-nil args for native types
@@ -77,7 +77,7 @@ func (h Helper) ParamWithNoConstr(name string) Param {
 	}
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (h Helper) Param(name string, constr Expr) Param {
 	return Param{
 		Name:   name,
@@ -89,7 +89,7 @@ type DefaultStringer string
 
 func (ds DefaultStringer) String() string { return string(ds) }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (h Helper) Trace(ss ...string) Trace {
 	if len(ss) == 0 {
 		panic("internal invariant violated: trace requires at least one element")

--- a/internal/compiler/typesystem/resolver.go
+++ b/internal/compiler/typesystem/resolver.go
@@ -49,14 +49,14 @@ type (
 
 // ResolveExpr resolves given expression using only global scope.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (r Resolver) ResolveExpr(expr Expr, scope Scope) (Expr, error) {
 	return r.resolveExpr(expr, scope, map[string]Def{}, nil)
 }
 
 // ResolveExprWithFrame works like ResolveExpr but allows to pass local scope.
 func (r Resolver) ResolveExprWithFrame(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	expr Expr,
 	frame map[string]Def,
 	scope Scope,
@@ -66,14 +66,14 @@ func (r Resolver) ResolveExprWithFrame(
 
 // ResolveExprWithFrame works like ResolveExprWithFrame but for list of expressions.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (r Resolver) ResolveExprsWithFrame(
 	exprs []Expr,
 	frame map[string]Def,
 	scope Scope,
 ) ([]Expr, error) {
 	resolvedExprs := make([]Expr, 0, len(exprs))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, expr := range exprs {
 		resolvedExpr, err := r.resolveExpr(expr, scope, frame, nil)
 		if err != nil {
@@ -95,7 +95,7 @@ func (r Resolver) ResolveParams(
 ) {
 	result := make([]Param, 0, len(params))
 	frame := make(map[string]Def, len(params))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, param := range params {
 		resolved, err := r.resolveExpr(param.Constr, scope, frame, nil)
 		if err != nil {
@@ -113,7 +113,7 @@ func (r Resolver) ResolveParams(
 // IsSubtypeOf resolves both `sub` and `sup` expressions
 // and returns error if `sub` is not subtype of `sup`.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (r Resolver) IsSubtypeOf(sub, sup Expr, scope Scope) error {
 	resolvedSub, err := r.resolveExpr(sub, scope, nil, nil)
 	if err != nil {
@@ -123,7 +123,7 @@ func (r Resolver) IsSubtypeOf(sub, sup Expr, scope Scope) error {
 	if err != nil {
 		return fmt.Errorf("resolve sup expr: %w", err)
 	}
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return r.checker.Check(
 		resolvedSub,
 		resolvedSup,
@@ -161,7 +161,7 @@ func (r Resolver) CheckArgsCompatibility(args []Expr, params []Param, scope Scop
 			resolvedSup,
 			TerminatorParams{Scope: scope},
 		); err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 	}
@@ -179,9 +179,9 @@ func (r Resolver) CheckArgsCompatibility(args []Expr, params []Param, scope Scop
 // for struct and union apply recursion for it's every field/element.
 //
 //nolint:gocyclo // Resolver covers many expression shapes and recursive cases.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (r Resolver) resolveExpr( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (r Resolver) resolveExpr( //nolint:cyclop,funlen,gocognit,lll
+	//nolint:gocritic
 	expr Expr, // expression to be resolved
 	scope Scope, // global scope
 	frame map[string]Def, // local scope
@@ -217,7 +217,7 @@ func (r Resolver) resolveExpr( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 			return Expr{Lit: &LitExpr{Union: resolvedUnion}}, nil
 		case StructLitType:
 			resolvedStruct := make(map[string]Expr, len(expr.Lit.Struct))
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for field, fieldExpr := range expr.Lit.Struct {
 				// we create new trace with virtual ref "struct" (it's safe because it's reserved word)
 				// otherwise recursive definitions (e.g. error -> maybe<error>)
@@ -281,7 +281,7 @@ func (r Resolver) resolveExpr( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 
 	newFrame := make(map[string]Def, len(def.Params))
 	resolvedArgs := make([]Expr, 0, len(expr.Inst.Args))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range def.Params { // resolve args and constrs and check their compatibility
 		resolvedArg, err := r.resolveExpr(expr.Inst.Args[i], scope, frame, &newTrace)
 		if err != nil {
@@ -325,9 +325,9 @@ func (r Resolver) resolveExpr( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 	return r.resolveExpr(*def.BodyExpr, scopeWhereDefFound, newFrame, &newTrace)
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (Resolver) getDef(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	ref core.EntityRef,
 	frame map[string]Def,
 	scope Scope,

--- a/internal/compiler/typesystem/scope_test.go
+++ b/internal/compiler/typesystem/scope_test.go
@@ -1,6 +1,6 @@
 // This file implements Scope interface specifically for tests.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 package typesystem_test
 
 import (
@@ -14,7 +14,7 @@ var ErrDefaultScope = errors.New("default scope")
 
 type TestScope map[string]ts.Def
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s TestScope) IsTopType(expr ts.Expr) bool {
 	if expr.Inst == nil {
 		return false
@@ -22,7 +22,7 @@ func (s TestScope) IsTopType(expr ts.Expr) bool {
 	return expr.Inst.Ref.String() == "any"
 }
 
-//nolint:gocritic,ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,ireturn
 func (s TestScope) GetType(ref core.EntityRef) (ts.Def, ts.Scope, error) {
 	v, ok := s[ref.String()]
 	if !ok {

--- a/internal/compiler/typesystem/subtype_checker.go
+++ b/internal/compiler/typesystem/subtype_checker.go
@@ -35,13 +35,13 @@ type TerminatorParams struct {
 // It also takes traces for those expressions and scope to handle recursive types.
 //
 //nolint:gocyclo // Subtype checking has many structural cases.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll
+	//nolint:gocritic
 	expr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	constr Expr,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	params TerminatorParams,
 ) error {
 	if params.Scope.IsTopType(constr) {
@@ -62,7 +62,7 @@ func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 		)
 	}
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if isConstraintInstance { // both expr and constr are insts
 		isSubTypeRecursive, err := s.terminator.ShouldTerminate(
 			params.SubtypeTrace,
@@ -97,7 +97,7 @@ func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 			expr.Inst.Ref,
 			constr.Inst.Ref,
 		)
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for i := range constr.Inst.Args {
 			newExpr := expr.Inst.Args[i]
 			newConstr := constr.Inst.Args[i]
@@ -191,7 +191,7 @@ func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 			}
 			// HACK: we copy-paste this loop to avoid re-assigning to params variable
 			// because that leads to infinite nesting inside that struct because of recursive pointers
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for constrFieldName, constrField := range constr.Lit.Struct {
 				exprField, ok := expr.Lit.Struct[constrFieldName]
 				if !ok {
@@ -206,7 +206,7 @@ func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 			}
 			break
 		}
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for constrFieldName, constrField := range constr.Lit.Struct {
 			exprField, ok := expr.Lit.Struct[constrFieldName]
 			if !ok {
@@ -225,9 +225,9 @@ func (s SubtypeChecker) Check( //nolint:cyclop,funlen,gocognit,lll // TODO(stric
 }
 
 func (SubtypeChecker) getNewTerminatorParams(
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	old TerminatorParams,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	subRef, supRef core.EntityRef,
 ) TerminatorParams {
 	newSubtypeTrace := Trace{

--- a/internal/compiler/typesystem/terminator.go
+++ b/internal/compiler/typesystem/terminator.go
@@ -17,12 +17,12 @@ var (
 
 type Terminator struct{}
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (r Terminator) ShouldTerminate(cur Trace, scope Scope) (bool, error) {
 	return r.shouldTerminate(cur, scope, 0)
 }
 
-//nolint:cyclop,gocognit,gocritic,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocritic,gocyclo
 func (r Terminator) shouldTerminate(cur Trace, scope Scope, counter int) (bool, error) {
 	if counter > 1 {
 		return false, ErrCounter
@@ -73,21 +73,21 @@ func (r Terminator) shouldTerminate(cur Trace, scope Scope, counter int) (bool, 
 
 // getLast3AndSwap turns [... a b a] into [b a b]
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (Terminator) getLast3AndSwap(cur Trace) Trace {
 	t1 := Trace{prev: nil, cur: cur.prev.cur}
 	t2 := Trace{prev: &t1, cur: cur.cur}
 	return Trace{prev: &t2, cur: cur.prev.cur}
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func sameRefs(cur, prev core.EntityRef) bool {
 	a := cur.String()
 	b := prev.String()
 	return a == b
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func isRecursiveWrapper(ref core.EntityRef) bool {
 	return ref.Name == "maybe" && (ref.Pkg == "" || ref.Pkg == "builtin")
 }

--- a/internal/compiler/typesystem/trace.go
+++ b/internal/compiler/typesystem/trace.go
@@ -8,7 +8,7 @@ import (
 
 // Linked-list to handle recursive types
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type Trace struct {
 	prev *Trace
 	cur  core.EntityRef
@@ -16,7 +16,7 @@ type Trace struct {
 
 // O(2n)
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (t Trace) String() string {
 	lastToFirst := []core.EntityRef{}
 
@@ -38,7 +38,7 @@ func (t Trace) String() string {
 	return firstToLast.String() + "]"
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func NewTrace(prev *Trace, cur core.EntityRef) Trace {
 	return Trace{
 		prev: prev,

--- a/internal/compiler/typesystem/typesystem.go
+++ b/internal/compiler/typesystem/typesystem.go
@@ -20,7 +20,7 @@ func (def Def) String() string {
 	var params strings.Builder
 
 	params.WriteString("<")
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range def.Params {
 		params.WriteString(param.Name)
 		params.WriteString(" " + param.Constr.String())
@@ -40,7 +40,7 @@ type Param struct {
 
 // Instantiation or literal. Lit or Inst must be not nil, but not both
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type Expr struct {
 	Lit  *LitExpr  `json:"lit,omitempty"`
 	Inst *InstExpr `json:"inst,omitempty"`
@@ -50,15 +50,15 @@ type Expr struct {
 // String formats expression in a TS manner
 //
 //nolint:gocyclo // String formatting covers multiple expression shapes.
-//nolint:cyclop,funlen,gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (expr Expr) String() string { //nolint:cyclop,funlen,gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit
+func (expr Expr) String() string { //nolint:cyclop,funlen,gocognit,lll
 	if expr.Inst == nil && expr.Lit == nil {
 		return "empty"
 	}
 
 	var str string
 
-	//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:nestif
 	if expr.Lit != nil {
 		switch expr.Lit.Type() {
 		case EmptyLitType:
@@ -129,7 +129,7 @@ func (expr Expr) String() string { //nolint:cyclop,funlen,gocognit,lll // TODO(s
 	str = expr.Inst.Ref.String()
 	str += "<"
 
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, arg := range expr.Inst.Args {
 		str += arg.String()
 		if i < len(expr.Inst.Args)-1 {
@@ -143,7 +143,7 @@ func (expr Expr) String() string { //nolint:cyclop,funlen,gocognit,lll // TODO(s
 
 // Instantiation expression
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type InstExpr struct {
 	Args []Expr         `json:"args,omitempty"`
 	Ref  core.EntityRef `json:"ref"`
@@ -151,7 +151,7 @@ type InstExpr struct {
 
 // Literal expression. Only one field must be initialized
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type LitExpr struct {
 	Struct map[string]Expr  `json:"struct,omitempty"`
 	Union  map[string]*Expr `json:"union,omitempty"` // tag -> constraint
@@ -165,7 +165,7 @@ func (lit *LitExpr) Empty() bool {
 
 // Always call Validate before
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (lit *LitExpr) Type() LiteralType {
 	switch {
 	case lit == nil:

--- a/internal/compiler/typesystem/validator.go
+++ b/internal/compiler/typesystem/validator.go
@@ -17,7 +17,7 @@ var (
 
 // ValidateDef makes sure that type supports recursion only if it's base type and that parameters are valid
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (v Validator) ValidateDef(def Def) error {
 	if err := v.CheckParamUnique(def.Params); err != nil {
 		return errors.Join(ErrParams, err)
@@ -28,7 +28,7 @@ func (v Validator) ValidateDef(def Def) error {
 // CheckParamUnique doesn't validate constraints, only ensures uniqueness
 func (v Validator) CheckParamUnique(params []Param) error {
 	m := make(map[string]struct{}, len(params))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, param := range params {
 		if _, ok := m[param.Name]; ok {
 			return fmt.Errorf("%w: param", ErrParamDuplicate)
@@ -40,7 +40,7 @@ func (v Validator) CheckParamUnique(params []Param) error {
 // Validate makes shallow validation of expr.
 // It checks that it's inst or literal, not both and not neither; All insts are valid by default;
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (v Validator) Validate(expr Expr) error {
 	if expr.Lit.Empty() == (expr.Inst == nil) {
 		return ErrExprMustBeInstOrLit

--- a/internal/compiler/utils.go
+++ b/internal/compiler/utils.go
@@ -13,7 +13,7 @@ import (
 
 // Pointer allows to avoid creating of temporary variables just to take pointers.
 //
-//nolint:gocheckcompilerdirectives // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocheckcompilerdirectives
 //go:fix inline
 func Pointer[T any](v T) *T {
 	return new(v)
@@ -24,7 +24,7 @@ func ParseEntityRef(ctx context.Context, ref string) (core.EntityRef, error) {
 	// Call the generated Neva function
 	out, err := neva.ParseEntityRef(ctx, neva.ParseEntityRefInput{Ref: ref})
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return core.EntityRef{}, err
 	}
 

--- a/internal/runtime/funcs/accumulator.go
+++ b/internal/runtime/funcs/accumulator.go
@@ -9,35 +9,35 @@ import (
 
 type accumulator struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (a accumulator) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	initIn, err := io.In.Single("init")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	updIn, err := io.In.Single("upd")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	lastIn, err := io.In.Single("last")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	curOut, err := io.Out.Single("cur")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -63,7 +63,7 @@ func (a accumulator) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Cont
 				var dataMsg, lastMsg runtime.Msg
 				var dataOk, lastOk bool
 
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				var wg sync.WaitGroup
 
 				wg.Go(func() {

--- a/internal/runtime/funcs/and.go
+++ b/internal/runtime/funcs/and.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,30 +9,30 @@ import (
 
 type and struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p and) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	aIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	bIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	// TODO send false as soon as A in is false, but do it correctly
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			aMsg, ok := aIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/args.go
+++ b/internal/runtime/funcs/args.go
@@ -9,17 +9,17 @@ import (
 
 type args struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (a args) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	sigIn, err := io.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -30,7 +30,7 @@ func (a args) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), e
 
 		result := make([]runtime.Msg, len(os.Args))
 		for i := range os.Args {
-			//nolint:makezero // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:makezero
 			result = append(result, runtime.NewStringMsg(os.Args[i]))
 		}
 

--- a/internal/runtime/funcs/arr_port_to_list.go
+++ b/internal/runtime/funcs/arr_port_to_list.go
@@ -10,7 +10,7 @@ import (
 type arrayPortToList struct{}
 
 func (arrayPortToList) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(context.Context), error) {
@@ -21,7 +21,7 @@ func (arrayPortToList) Create(
 
 	listOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/arr_port_to_stream.go
+++ b/internal/runtime/funcs/arr_port_to_stream.go
@@ -10,7 +10,7 @@ import (
 type arrayPortToStream struct{}
 
 func (arrayPortToStream) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(context.Context), error) {
@@ -21,14 +21,14 @@ func (arrayPortToStream) Create(
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	// TODO: could be optimized by using portIn.ReceiveAll()
 	// but we need to handle order of sending messages to stream
 	return func(ctx context.Context) {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		l := portIn.Len()
 
 		for {

--- a/internal/runtime/funcs/atoi.go
+++ b/internal/runtime/funcs/atoi.go
@@ -11,23 +11,23 @@ import (
 
 type atoi struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (a atoi) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func (a atoi) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), e
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (a atoi) stringToRuntimeInt(str string) (runtime.Msg, error) {
 	v, err := strconv.Atoi(str) // equivalent to ParseInt(s, 10, 0)
 	if err != nil {

--- a/internal/runtime/funcs/bytes_from_string.go
+++ b/internal/runtime/funcs/bytes_from_string.go
@@ -8,17 +8,17 @@ import (
 
 type bytesFromString struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (bytesFromString) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/cond.go
+++ b/internal/runtime/funcs/cond.go
@@ -9,29 +9,29 @@ import (
 
 type cond struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (c cond) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	ifIn, err := io.In.Single("if")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	thenOut, err := io.Out.Single("then")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elseOut, err := io.Out.Single("else")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -40,7 +40,7 @@ func (c cond) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), e
 			var dataMsg, ifMsg runtime.Msg
 			var dataOk, ifOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/del.go
+++ b/internal/runtime/funcs/del.go
@@ -11,7 +11,7 @@ type del struct{}
 func (d del) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/dict_to_stream.go
+++ b/internal/runtime/funcs/dict_to_stream.go
@@ -9,19 +9,19 @@ import (
 type dictToStream struct{}
 
 func (dictToStream) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/dotenv_load.go
+++ b/internal/runtime/funcs/dotenv_load.go
@@ -21,23 +21,23 @@ type dotenvLoad struct {
 	override bool
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (d dotenvLoadFrom) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	filenameIn, err := rio.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := rio.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := rio.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -67,23 +67,23 @@ func (d dotenvLoadFrom) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.
 	}, nil
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (d dotenvLoad) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	sigIn, err := rio.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := rio.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := rio.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -111,7 +111,7 @@ func loadDotenvFile(path string, override bool) error {
 	// #nosec G304,G703 -- path comes from explicit component input (caller-controlled by design).
 	file, err := os.Open(path)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	defer file.Close()
@@ -168,7 +168,7 @@ func parseDotenv(r io.Reader) (map[string]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -219,12 +219,12 @@ func parseDotenvValue(raw string) (string, error) {
 	return raw, nil
 }
 
-//nolint:cyclop,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocyclo,varnamelen
 func unescapeDoubleQuoted(s string) (string, error) {
 	var builder strings.Builder
 	builder.Grow(len(s))
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
 		if ch != '\\' {
@@ -264,14 +264,14 @@ func unescapeDoubleQuoted(s string) (string, error) {
 	return builder.String(), nil
 }
 
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func stripInlineComment(value string) string {
 	value = strings.TrimRightFunc(value, unicode.IsSpace)
 
 	inSingle := false
 	inDouble := false
 
-	//nolint:intrange,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:intrange,varnamelen
 	for i := 0; i < len(value); i++ {
 		switch value[i] {
 		case '\'':
@@ -301,7 +301,7 @@ func stripInlineComment(value string) string {
 	return strings.TrimSpace(value)
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func isEscaped(s string, idx int) bool {
 	if idx == 0 {
 		return false

--- a/internal/runtime/funcs/eq.go
+++ b/internal/runtime/funcs/eq.go
@@ -9,30 +9,30 @@ import (
 
 type eq struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p eq) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
 			var (
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				wg                   sync.WaitGroup
 				val1, val2           runtime.Msg
 				actualOk, comparedOk bool

--- a/internal/runtime/funcs/errors_new.go
+++ b/internal/runtime/funcs/errors_new.go
@@ -9,19 +9,19 @@ import (
 type errorsNew struct{}
 
 func (errorsNew) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/fan_in.go
+++ b/internal/runtime/funcs/fan_in.go
@@ -8,17 +8,17 @@ import (
 
 type fanIn struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (fanIn) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	data, err := io.In.Array("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/fan_out.go
+++ b/internal/runtime/funcs/fan_out.go
@@ -8,17 +8,17 @@ import (
 
 type fanOut struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (d fanOut) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	dataOut, err := io.Out.Array("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/field.go
+++ b/internal/runtime/funcs/field.go
@@ -9,7 +9,7 @@ import (
 
 type structField struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (s structField) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Context), error) {
 	path := cfg.List()
 	if len(path) == 0 {
@@ -23,13 +23,13 @@ func (s structField) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Co
 
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -47,7 +47,7 @@ func (s structField) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Co
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (structField) selector(m runtime.Msg, path []string) runtime.Msg {
 	for len(path) > 0 {
 		m = m.Struct().Get(path[0])

--- a/internal/runtime/funcs/file_read_all.go
+++ b/internal/runtime/funcs/file_read_all.go
@@ -10,23 +10,23 @@ import (
 
 type fileReadAll struct{}
 
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func (c fileReadAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	filenameIn, err := rio.In.Single("filename")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := rio.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := rio.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -37,7 +37,7 @@ func (c fileReadAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Con
 				return
 			}
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			f, err := os.Open(name.Str())
 			if err != nil {
 				if !errOut.Send(ctx, errFromErr(err)) {

--- a/internal/runtime/funcs/float_add.go
+++ b/internal/runtime/funcs/float_add.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type floatAdd struct{}
 
 func (floatAdd) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (floatAdd) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/float_div.go
+++ b/internal/runtime/funcs/float_div.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type floatDiv struct{}
 
 func (floatDiv) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (floatDiv) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/float_from_int.go
+++ b/internal/runtime/funcs/float_from_int.go
@@ -9,19 +9,19 @@ import (
 type floatFromInt struct{}
 
 func (floatFromInt) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/float_is_greater.go
+++ b/internal/runtime/funcs/float_is_greater.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type floatIsGreater struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p floatIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			val1, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/float_is_lesser.go
+++ b/internal/runtime/funcs/float_is_lesser.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type floatIsLesser struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p floatIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			val1, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/float_mul.go
+++ b/internal/runtime/funcs/float_mul.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type floatMul struct{}
 
 func (floatMul) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (floatMul) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/float_neg.go
+++ b/internal/runtime/funcs/float_neg.go
@@ -8,17 +8,17 @@ import (
 
 type floatNeg struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (floatNeg) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/float_sub.go
+++ b/internal/runtime/funcs/float_sub.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type floatSub struct{}
 
 func (floatSub) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	leftIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	rightIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (floatSub) Create(
 			var leftMsg, rightMsg runtime.Msg
 			var leftOk, rightOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/format_bool.go
+++ b/internal/runtime/funcs/format_bool.go
@@ -10,19 +10,19 @@ import (
 type formatBool struct{}
 
 func (formatBool) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/format_float.go
+++ b/internal/runtime/funcs/format_float.go
@@ -9,45 +9,45 @@ import (
 
 type formatFloat struct{}
 
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func (formatFloat) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	fmtIn, err := io.In.Single("fmt")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	precIn, err := io.In.Single("prec")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	bitsIn, err := io.In.Single("bits")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			data, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/format_int.go
+++ b/internal/runtime/funcs/format_int.go
@@ -10,31 +10,31 @@ import (
 type formatInt struct{}
 
 func (formatInt) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	baseIn, err := io.In.Single("base")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			data, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/get.go
+++ b/internal/runtime/funcs/get.go
@@ -9,29 +9,29 @@ import (
 
 type getDictValue struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (g getDictValue) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dictIn, err := io.In.Single("dict")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	keyIn, err := io.In.Single("key")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (g getDictValue) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Con
 				dictOk, keyOk   bool
 			)
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			wg := sync.WaitGroup{}
 			wg.Go(func() {
 				dictMsg, dictOk = dictIn.Receive(ctx)

--- a/internal/runtime/funcs/http.go
+++ b/internal/runtime/funcs/http.go
@@ -10,23 +10,23 @@ import (
 
 type httpGet struct{}
 
-//nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo
 func (httpGet) Create(funcIO runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	urlIn, err := funcIO.In.Single("url")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := funcIO.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := funcIO.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -37,7 +37,7 @@ func (httpGet) Create(funcIO runtime.IO, _ runtime.Msg) (func(ctx context.Contex
 				return
 			}
 
-			//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:noctx
 			resp, err := http.Get(urlMsg.Str())
 			if err != nil {
 				if !errOut.Send(ctx, errFromErr(err)) {

--- a/internal/runtime/funcs/image.go
+++ b/internal/runtime/funcs/image.go
@@ -9,7 +9,7 @@ import (
 
 // TODO can't we use uint8 here?
 //
-//nolint:recvcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:recvcheck
 type rgbaMsg struct {
 	r int64
 	g int64

--- a/internal/runtime/funcs/image_encode.go
+++ b/internal/runtime/funcs/image_encode.go
@@ -10,23 +10,23 @@ import (
 
 type imageEncode struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (imageEncode) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	imgIn, err := io.In.Single("img")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (imageEncode) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Contex
 			}
 
 			imgStructMsg := imgMsg.Struct()
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			b := imageMsg{
 				pixels: imgStructMsg.Get("pixels").Bytes(),
 				width:  imgStructMsg.Get("width").Int(),
@@ -48,7 +48,7 @@ func (imageEncode) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Contex
 			im := b.createImage()
 
 			// Encode the image in the desired format to sb.
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var sb bytes.Buffer // for encoded output.
 			if err := png.Encode(&sb, im); err != nil {
 				if !errOut.Send(ctx, errFromErr(err)) {

--- a/internal/runtime/funcs/image_new.go
+++ b/internal/runtime/funcs/image_new.go
@@ -9,29 +9,29 @@ import (
 
 type imageNew struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (imageNew) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	pixelsIn, err := io.In.Single("pixels")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	imgOut, err := io.Out.Single("img")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			im := make(map[pixelMsg]struct{})
 			var (
 				width  int64
@@ -39,7 +39,7 @@ func (imageNew) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 			)
 		stream:
 			for {
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				m, ok := pixelsIn.Receive(ctx)
 				if !ok {
 					return

--- a/internal/runtime/funcs/int_add.go
+++ b/internal/runtime/funcs/int_add.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intAdd struct{}
 
 func (intAdd) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intAdd) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_bitwise_and.go
+++ b/internal/runtime/funcs/int_bitwise_and.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intBitwiseAnd struct{}
 
 func (intBitwiseAnd) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intBitwiseAnd) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_bitwise_lsh.go
+++ b/internal/runtime/funcs/int_bitwise_lsh.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intBitwiseLsh struct{}
 
 func (intBitwiseLsh) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intBitwiseLsh) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_bitwise_or.go
+++ b/internal/runtime/funcs/int_bitwise_or.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intBitwiseOr struct{}
 
 func (intBitwiseOr) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intBitwiseOr) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_bitwise_rsh.go
+++ b/internal/runtime/funcs/int_bitwise_rsh.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intBitwiseRsh struct{}
 
 func (intBitwiseRsh) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intBitwiseRsh) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_bitwise_xor.go
+++ b/internal/runtime/funcs/int_bitwise_xor.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intBitwiseXor struct{}
 
 func (intBitwiseXor) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intBitwiseXor) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_decr.go
+++ b/internal/runtime/funcs/int_decr.go
@@ -8,17 +8,17 @@ import (
 
 type intDec struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (i intDec) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/int_div.go
+++ b/internal/runtime/funcs/int_div.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intDiv struct{}
 
 func (intDiv) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intDiv) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_from_float.go
+++ b/internal/runtime/funcs/int_from_float.go
@@ -9,19 +9,19 @@ import (
 type intFromFloat struct{}
 
 func (intFromFloat) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/int_inc.go
+++ b/internal/runtime/funcs/int_inc.go
@@ -8,17 +8,17 @@ import (
 
 type intInc struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (i intInc) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/int_is_greater.go
+++ b/internal/runtime/funcs/int_is_greater.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type intIsGreater struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p intIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			actualMsg, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/int_is_greater_or_equal.go
+++ b/internal/runtime/funcs/int_is_greater_or_equal.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intIsGreaterOrEqual struct{}
 
 func (intIsGreaterOrEqual) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intIsGreaterOrEqual) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_is_lesser.go
+++ b/internal/runtime/funcs/int_is_lesser.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type intIsLesser struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p intIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			actualMsg, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/int_is_lesser_or_equal.go
+++ b/internal/runtime/funcs/int_is_lesser_or_equal.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intIsLesserOrEqual struct{}
 
 func (intIsLesserOrEqual) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intIsLesserOrEqual) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_mod.go
+++ b/internal/runtime/funcs/int_mod.go
@@ -8,29 +8,29 @@ import (
 
 type intMod struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (intMod) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	leftIn, err := io.In.Single("left") // numerator
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	denIn, err := io.In.Single("right") // denominator
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res") // modulo
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			numMsg, ok := leftIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/int_mul.go
+++ b/internal/runtime/funcs/int_mul.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intMul struct{}
 
 func (intMul) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intMul) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_neg.go
+++ b/internal/runtime/funcs/int_neg.go
@@ -8,17 +8,17 @@ import (
 
 type intNeg struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (intNeg) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/int_pow.go
+++ b/internal/runtime/funcs/int_pow.go
@@ -10,25 +10,25 @@ import (
 type intPow struct{}
 
 func (intPow) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -37,7 +37,7 @@ func (intPow) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/int_sub.go
+++ b/internal/runtime/funcs/int_sub.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type intSub struct{}
 
 func (intSub) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	accIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,7 +38,7 @@ func (intSub) Create(
 			var accMsg, elMsg runtime.Msg
 			var accOk, elOk bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/itoa.go
+++ b/internal/runtime/funcs/itoa.go
@@ -10,19 +10,19 @@ import (
 type itoa struct{}
 
 func (itoa) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/list_at.go
+++ b/internal/runtime/funcs/list_at.go
@@ -8,35 +8,35 @@ import (
 
 type listAt struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (listAt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	idxIn, err := io.In.Single("idx")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/list_len.go
+++ b/internal/runtime/funcs/list_len.go
@@ -8,17 +8,17 @@ import (
 
 type listlen struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p listlen) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/list_push.go
+++ b/internal/runtime/funcs/list_push.go
@@ -9,28 +9,28 @@ import (
 
 type listPush struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p listPush) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	lstIn, err := io.In.Single("lst")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/list_slice.go
+++ b/internal/runtime/funcs/list_slice.go
@@ -15,29 +15,29 @@ func sliceList(data []runtime.Msg, from int64, to int64) []runtime.Msg {
 	return append([]runtime.Msg(nil), data[start:end]...)
 }
 
-//nolint:dupl,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl,varnamelen
 func (listSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	fromIn, err := io.In.Single("from")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	toIn, err := io.In.Single("to")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -46,7 +46,7 @@ func (listSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), er
 			var dataMsg, fromMsg, toMsg runtime.Msg
 			var dataOK, fromOK, toOK bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 			wg.Go(func() {
 				dataMsg, dataOK = dataIn.Receive(ctx)

--- a/internal/runtime/funcs/list_to_stream.go
+++ b/internal/runtime/funcs/list_to_stream.go
@@ -9,19 +9,19 @@ import (
 type listToStream struct{}
 
 func (c listToStream) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/lock.go
+++ b/internal/runtime/funcs/lock.go
@@ -9,30 +9,30 @@ import (
 
 type lock struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (l lock) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	sigIn, err := io.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
 			var (
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				wg            sync.WaitGroup
 				data          runtime.Msg
 				dataOk, sigOk bool

--- a/internal/runtime/funcs/match.go
+++ b/internal/runtime/funcs/match.go
@@ -9,23 +9,23 @@ import (
 
 type matchSelector struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (matchSelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	ifIn, err := io.In.Array("if")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	thenOut, err := io.In.Array("then")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -35,19 +35,19 @@ func (matchSelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Cont
 
 	elseIn, err := io.In.Single("else")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/ne.go
+++ b/internal/runtime/funcs/ne.go
@@ -9,30 +9,30 @@ import (
 
 type notEq struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p notEq) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
 			var (
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				wg                   sync.WaitGroup
 				val1, val2           runtime.Msg
 				actualOk, comparedOk bool

--- a/internal/runtime/funcs/new.go
+++ b/internal/runtime/funcs/new.go
@@ -8,17 +8,17 @@ import (
 
 type newV2 struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (c newV2) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Context), error) {
 	sigIn, err := io.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/not.go
+++ b/internal/runtime/funcs/not.go
@@ -8,16 +8,16 @@ import (
 
 type not struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p not) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/or.go
+++ b/internal/runtime/funcs/or.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type or struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p or) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	aIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	bIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			aMsg, ok := aIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/os_environ.go
+++ b/internal/runtime/funcs/os_environ.go
@@ -9,17 +9,17 @@ import (
 
 type osEnviron struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (o osEnviron) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	sigIn, err := io.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/panic.go
+++ b/internal/runtime/funcs/panic.go
@@ -16,7 +16,7 @@ func (p panicker) Create(
 ) (func(ctx context.Context), error) {
 	msgIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/parse_bool.go
+++ b/internal/runtime/funcs/parse_bool.go
@@ -10,27 +10,27 @@ import (
 
 type parseBool struct{}
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (parseBool) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/parse_float.go
+++ b/internal/runtime/funcs/parse_float.go
@@ -11,35 +11,35 @@ import (
 
 type parseFloat struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (p parseFloat) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	bitsIn, err := io.In.Single("bits")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return
@@ -65,7 +65,7 @@ func (p parseFloat) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Conte
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (p parseFloat) stringToRuntimeFloat(
 	data runtime.Msg,
 	bits runtime.Msg,

--- a/internal/runtime/funcs/parse_int.go
+++ b/internal/runtime/funcs/parse_int.go
@@ -11,41 +11,41 @@ import (
 
 type parseInt struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (p parseInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	baseIn, err := io.In.Single("base")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	bitsIn, err := io.In.Single("bits")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return
@@ -76,13 +76,13 @@ func (p parseInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (p parseInt) stringToRuntimeInt(
 	data runtime.Msg,
 	base runtime.Msg,
 	bits runtime.Msg,
 ) (runtime.Msg, error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	v, err := strconv.ParseInt(
 		data.Str(),
 		int(base.Int()),

--- a/internal/runtime/funcs/print.go
+++ b/internal/runtime/funcs/print.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -10,23 +10,23 @@ import (
 
 type printFunc struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (printFunc) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/printf.go
+++ b/internal/runtime/funcs/printf.go
@@ -11,39 +11,39 @@ import (
 
 type printf struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p printf) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	tplIn, err := io.In.Single("tpl")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	argsIn, err := io.In.Array("args")
 	if err != nil {
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return nil, fmt.Errorf("missing required input port 'args'")
 	}
 
 	sigOut, err := io.Out.Single("sig")
 	if err != nil {
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return nil, fmt.Errorf("missing required output port 'args'")
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return p.handle(tplIn, argsIn, errOut, sigOut)
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (printf) handle(
 	tplIn runtime.SingleInport,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	argsIn runtime.ArrayInport,
 	errOut runtime.SingleOutport,
 	sigOut runtime.SingleOutport,
@@ -85,7 +85,7 @@ func (printf) handle(
 	}, nil
 }
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func format(tpl string, args []runtime.Msg) (string, error) {
 	// Use a map to keep track of which arguments have been used
 	usedArgs := make(map[int]bool)
@@ -95,13 +95,13 @@ func format(tpl string, args []runtime.Msg) (string, error) {
 	result.Grow(len(tpl)) // Optimistically assume no increase in length
 
 	// Scan through the template to find and replace placeholders
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	i := 0
 	for i < len(tpl) {
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if tpl[i] == '$' {
 			// Attempt to read an argument index after the '$'
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			j := i + 1
 			var argIndexStr strings.Builder
 			for j < len(tpl) && tpl[j] >= '0' && tpl[j] <= '9' {

--- a/internal/runtime/funcs/println.go
+++ b/internal/runtime/funcs/println.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -10,23 +10,23 @@ import (
 
 type printlnFunc struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (printlnFunc) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/race.go
+++ b/internal/runtime/funcs/race.go
@@ -10,23 +10,23 @@ import (
 
 type race struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (race) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	casesArrIn, err := io.In.Array("case")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	casesOut, err := io.Out.Array("case")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -36,7 +36,7 @@ func (race) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), err
 
 	return func(ctx context.Context) {
 		var (
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			wg      sync.WaitGroup
 			dataMsg runtime.Msg
 			dataOk  bool

--- a/internal/runtime/funcs/range_int.go
+++ b/internal/runtime/funcs/range_int.go
@@ -8,29 +8,29 @@ import (
 
 type rangeInt struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	fromIn, err := io.In.Single("from")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	toIn, err := io.In.Single("to")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			fromMsg, ok := fromIn.Receive(ctx)
 			if !ok {
 				return
@@ -43,7 +43,7 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 
 			var (
 				from = fromMsg.Int()
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				to = toMsg.Int()
 
 				idx  = int64(0)
@@ -51,7 +51,7 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 				data = from
 			)
 
-			//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:nestif
 			if from < to {
 				for !last {
 					if data == to-1 {

--- a/internal/runtime/funcs/regexp_submatch.go
+++ b/internal/runtime/funcs/regexp_submatch.go
@@ -10,35 +10,35 @@ import (
 
 type regexpSubmatch struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (r regexpSubmatch) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	regexpIn, err := io.In.Single("regexp")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			regexpMsg, ok := regexpIn.Receive(ctx)
 			if !ok {
 				return
@@ -71,7 +71,7 @@ func (r regexpSubmatch) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.C
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func stringsToList(ss []string) runtime.Msg {
 	msgs := make([]runtime.Msg, 0, len(ss))
 	for _, s := range ss {

--- a/internal/runtime/funcs/registry.go
+++ b/internal/runtime/funcs/registry.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nevalang/neva/internal/runtime"
 )
 
-//nolint:funlen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:funlen
 func NewRegistry() map[string]runtime.FuncCreator {
 	return map[string]runtime.FuncCreator{
 		"new":     newV2{},

--- a/internal/runtime/funcs/scanln.go
+++ b/internal/runtime/funcs/scanln.go
@@ -11,24 +11,24 @@ type scanln struct{}
 
 // TODO add `:err` outport
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (r scanln) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) { //nolint:gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
+//nolint:gocognit
+func (r scanln) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) { //nolint:gocognit,lll
 	sigIn, err := rio.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := rio.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := rio.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/select.go
+++ b/internal/runtime/funcs/select.go
@@ -9,17 +9,17 @@ import (
 
 type selector struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (selector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	ifArrIn, err := io.In.Array("if")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	thenArrIn, err := io.In.Array("then")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -29,7 +29,7 @@ func (selector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/slice_bounds.go
+++ b/internal/runtime/funcs/slice_bounds.go
@@ -4,7 +4,7 @@ package funcs
 // Negative indices are interpreted from the end, all bounds are clamped to [0, length],
 // and out-of-order ranges become empty slices.
 //
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func normalizeSliceBounds(from int64, to int64, length int64) (start int64, end int64) {
 	start = normalizeSliceIndex(from, length)
 	end = normalizeSliceIndex(to, length)

--- a/internal/runtime/funcs/stream_product.go
+++ b/internal/runtime/funcs/stream_product.go
@@ -9,27 +9,27 @@ import (
 
 type streamProduct struct{}
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (streamProduct) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	firstIn, err := io.In.Single("first")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	secondIn, err := io.In.Single("second")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (streamProduct) Create(
 				secondData        = []runtime.Msg{}
 			)
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {
@@ -85,9 +85,9 @@ func (streamProduct) Create(
 				return
 			}
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			for i, firstMsg := range firstData {
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				for j, secondMsg := range secondData {
 					resOut.Send(
 						ctx,

--- a/internal/runtime/funcs/stream_to_dict.go
+++ b/internal/runtime/funcs/stream_to_dict.go
@@ -9,19 +9,19 @@ import (
 type streamToDict struct{}
 
 func (streamToDict) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/stream_to_list.go
+++ b/internal/runtime/funcs/stream_to_list.go
@@ -9,19 +9,19 @@ import (
 type streamToList struct{}
 
 func (s streamToList) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	seqIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/stream_zip.go
+++ b/internal/runtime/funcs/stream_zip.go
@@ -8,34 +8,34 @@ import (
 
 type streamZip struct{}
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (streamZip) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	leftIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	rightIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		var idx int64
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			leftMsg, ok := leftIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/stream_zip_many.go
+++ b/internal/runtime/funcs/stream_zip_many.go
@@ -10,21 +10,21 @@ import (
 
 type streamZipMany struct{}
 
-//nolint:cyclop,funlen,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocyclo
 func (streamZipMany) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Array("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func (streamZipMany) Create(
 			var shouldStop atomic.Bool
 			var aborted atomic.Bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 			wg.Add(streamsCount)
 
@@ -87,7 +87,7 @@ func (streamZipMany) Create(
 				}
 			}
 
-			//nolint:intrange // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:intrange
 			for idx := 0; idx < count; idx++ {
 				zipped := make([]runtime.Msg, streamsCount)
 				for streamIdx := range streamsCount {

--- a/internal/runtime/funcs/string_add.go
+++ b/internal/runtime/funcs/string_add.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -11,25 +11,25 @@ import (
 type stringAdd struct{}
 
 func (stringAdd) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	leftIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	rightIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -37,7 +37,7 @@ func (stringAdd) Create(
 		for {
 			var leftMsg, rightMsg runtime.Msg
 			var leftOk, rightOk bool
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 
 			wg.Go(func() {

--- a/internal/runtime/funcs/string_at.go
+++ b/internal/runtime/funcs/string_at.go
@@ -9,35 +9,35 @@ import (
 
 type stringAt struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (stringAt) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	idxIn, err := io.In.Single("idx")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := io.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/string_from_int_codepoint.go
+++ b/internal/runtime/funcs/string_from_int_codepoint.go
@@ -10,19 +10,19 @@ import (
 type stringFromIntCodepoint struct{}
 
 func (stringFromIntCodepoint) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -41,7 +41,7 @@ func (stringFromIntCodepoint) Create(
 	}, nil
 }
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func codePointString(v int64) string {
 	if v < 0 || v > unicode.MaxRune || (v >= 0xD800 && v <= 0xDFFF) {
 		return string(unicode.ReplacementChar)

--- a/internal/runtime/funcs/string_is_greater.go
+++ b/internal/runtime/funcs/string_is_greater.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type strIsGreater struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p strIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			val1, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/string_is_lesser.go
+++ b/internal/runtime/funcs/string_is_lesser.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl
 package funcs
 
 import (
@@ -9,29 +9,29 @@ import (
 
 type strIsLesser struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p strIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	actualIn, err := io.In.Single("left")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	comparedIn, err := io.In.Single("right")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			val1, ok := actualIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/string_join.go
+++ b/internal/runtime/funcs/string_join.go
@@ -9,29 +9,29 @@ import (
 
 type stringJoinList struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (stringJoinList) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	sepIn, err := io.In.Single("sep")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return
@@ -62,23 +62,23 @@ func (stringJoinList) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Con
 
 type stringJoinStream struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (stringJoinStream) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	sepIn, err := io.In.Single("sep")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/string_slice.go
+++ b/internal/runtime/funcs/string_slice.go
@@ -16,29 +16,29 @@ func sliceString(data string, from int64, to int64) string {
 	return string(runes[start:end])
 }
 
-//nolint:dupl,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:dupl,varnamelen
 func (stringSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	fromIn, err := io.In.Single("from")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	toIn, err := io.In.Single("to")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -47,7 +47,7 @@ func (stringSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), 
 			var dataMsg, fromMsg, toMsg runtime.Msg
 			var dataOK, fromOK, toOK bool
 
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 			wg.Go(func() {
 				dataMsg, dataOK = dataIn.Receive(ctx)

--- a/internal/runtime/funcs/string_split.go
+++ b/internal/runtime/funcs/string_split.go
@@ -9,29 +9,29 @@ import (
 
 type stringsSplit struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (p stringsSplit) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	delimIn, err := io.In.Single("delim")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			data, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/string_to_stream.go
+++ b/internal/runtime/funcs/string_to_stream.go
@@ -9,19 +9,19 @@ import (
 type stringToStream struct{}
 
 func (stringToStream) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/strings_from_bytes.go
+++ b/internal/runtime/funcs/strings_from_bytes.go
@@ -8,17 +8,17 @@ import (
 
 type stringsFromBytes struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (stringsFromBytes) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/strings_to_lower.go
+++ b/internal/runtime/funcs/strings_to_lower.go
@@ -9,17 +9,17 @@ import (
 
 type stringsToLower struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p stringsToLower) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/strings_to_upper.go
+++ b/internal/runtime/funcs/strings_to_upper.go
@@ -9,17 +9,17 @@ import (
 
 type stringsToUpper struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (p stringsToUpper) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/struct.go
+++ b/internal/runtime/funcs/struct.go
@@ -11,7 +11,7 @@ import (
 type structBuilder struct{}
 
 func (s structBuilder) Create(
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
@@ -29,7 +29,7 @@ func (s structBuilder) Create(
 
 	outport, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -43,9 +43,9 @@ func (structBuilder) Handle(
 	return func(ctx context.Context) {
 		for {
 			fields := make([]runtime.StructField, 0, len(inports))
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var mu sync.Mutex
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			var wg sync.WaitGroup
 			for inportName, inportChan := range inports {
 				wg.Go(func() {

--- a/internal/runtime/funcs/switch.go
+++ b/internal/runtime/funcs/switch.go
@@ -10,29 +10,29 @@ import (
 
 type switchRouter struct{}
 
-//nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,gocognit,gocyclo,varnamelen
 func (switchRouter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	caseArrIn, err := io.In.Array("case")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	caseOut, err := io.Out.Array("case")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elseOut, err := io.Out.Single("else")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func (switchRouter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Conte
 	return func(ctx context.Context) {
 		for {
 			var (
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				wg              sync.WaitGroup
 				dataMsg         runtime.Msg
 				cases           = make([]runtime.Msg, caseArrIn.Len())
@@ -95,9 +95,9 @@ func (switchRouter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Conte
 	}, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func tryToUnboxIfUnion(dataMsg runtime.Msg) runtime.Msg {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	u, ok := dataMsg.(runtime.UnionMsg)
 	if !ok {
 		return dataMsg

--- a/internal/runtime/funcs/ternary.go
+++ b/internal/runtime/funcs/ternary.go
@@ -8,35 +8,35 @@ import (
 
 type ternarySelector struct{}
 
-//nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit,varnamelen
 func (p ternarySelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	ifIn, err := io.In.Single("if")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	thenIn, err := io.In.Single("then")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	elseIn, err := io.In.Single("else")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := ifIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/time_delay.go
+++ b/internal/runtime/funcs/time_delay.go
@@ -9,29 +9,29 @@ import (
 
 type timeDelay struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (timeDelay) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	durIn, err := io.In.Single("dur")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			durMsg, ok := durIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/time_sleep.go
+++ b/internal/runtime/funcs/time_sleep.go
@@ -9,17 +9,17 @@ import (
 
 type timeAfter struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (timeAfter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	durIn, err := io.In.Single("dur")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	sigOut, err := io.Out.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 

--- a/internal/runtime/funcs/union.go
+++ b/internal/runtime/funcs/union.go
@@ -8,29 +8,29 @@ import (
 
 type unionWrapper struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (unionWrapper) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	dataIn, err := io.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	tagIn, err := io.In.Single("tag")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := io.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			dataMsg, ok := dataIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/funcs/wait_group.go
+++ b/internal/runtime/funcs/wait_group.go
@@ -8,23 +8,23 @@ import (
 
 type waitGroup struct{}
 
-//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:varnamelen
 func (g waitGroup) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	countIn, err := io.In.Single("count")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	sigIn, err := io.In.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	sigOut, err := io.Out.Single("sig")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -38,13 +38,13 @@ func (waitGroup) Handle(
 ) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			n, ok := countIn.Receive(ctx)
 			if !ok {
 				return
 			}
 
-			//nolint:intrange // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:intrange
 			for i := int64(0); i < n.Int(); i++ {
 				if _, ok := sigIn.Receive(ctx); !ok {
 					return

--- a/internal/runtime/funcs/write_all.go
+++ b/internal/runtime/funcs/write_all.go
@@ -9,35 +9,35 @@ import (
 
 type writeAll struct{}
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func (c writeAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
 	filenameIn, err := rio.In.Single("filename")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	dataIn, err := rio.In.Single("data")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	resOut, err := rio.Out.Single("res")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	errOut, err := rio.Out.Single("err")
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:varnamelen
 			filenameMsg, ok := filenameIn.Receive(ctx)
 			if !ok {
 				return

--- a/internal/runtime/interceptors.go
+++ b/internal/runtime/interceptors.go
@@ -10,13 +10,13 @@ type ProdInterceptor struct{}
 
 func (ProdInterceptor) Prepare() error { return nil }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (ProdInterceptor) Sent(sender PortSlotAddr, msg Msg) Msg { return msg }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (ProdInterceptor) Received(receiver PortSlotAddr, msg Msg) Msg { return msg }
 
-//nolint:recvcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:recvcheck
 type DebugInterceptor struct {
 	file    *os.File
 	comment string
@@ -25,18 +25,18 @@ type DebugInterceptor struct {
 func (d *DebugInterceptor) Open(filepath string) (func() error, error) {
 	file, err := os.OpenFile(filepath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|os.O_APPEND, 0644)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	d.file = file
 	if _, err := fmt.Fprintln(d.file, d.comment); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	return file.Close, nil
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (d *DebugInterceptor) Sent(sender PortSlotAddr, msg Msg) Msg {
 	fmt.Fprintf(
 		d.file,
@@ -46,7 +46,7 @@ func (d *DebugInterceptor) Sent(sender PortSlotAddr, msg Msg) Msg {
 	return msg
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (d *DebugInterceptor) Received(receiver PortSlotAddr, msg Msg) Msg {
 	fmt.Fprintf(
 		d.file,

--- a/internal/runtime/message.go
+++ b/internal/runtime/message.go
@@ -122,7 +122,7 @@ func NewFloatMsg(n float64) FloatMsg {
 
 // --- STRING ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type StringMsg struct {
 	internalMsg
 	v string
@@ -133,7 +133,7 @@ func (msg StringMsg) Str() string { return msg.v }
 func (msg StringMsg) String() string { return msg.v }
 
 func (msg StringMsg) MarshalJSON() ([]byte, error) {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return json.Marshal(msg.String())
 }
 
@@ -151,7 +151,7 @@ func NewStringMsg(s string) StringMsg {
 
 // --- BYTES ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type BytesMsg struct {
 	internalMsg
 	v []byte
@@ -168,7 +168,7 @@ func (msg BytesMsg) String() string {
 }
 
 func (msg BytesMsg) MarshalJSON() ([]byte, error) {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return json.Marshal(msg.v)
 }
 
@@ -186,7 +186,7 @@ func NewBytesMsg(v []byte) BytesMsg {
 
 // --- LIST ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type ListMsg struct {
 	internalMsg
 	v []Msg
@@ -201,7 +201,7 @@ func (msg ListMsg) String() string {
 	return string(bb)
 }
 
-//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:wrapcheck
 func (msg ListMsg) MarshalJSON() ([]byte, error) { return json.Marshal(msg.v) }
 func (msg ListMsg) Equal(other Msg) bool {
 	otherList, ok := other.(ListMsg)
@@ -228,7 +228,7 @@ func NewListMsg(v []Msg) ListMsg {
 
 // --- DICT ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type DictMsg struct {
 	internalMsg
 	v map[string]Msg
@@ -238,7 +238,7 @@ func (msg DictMsg) Dict() map[string]Msg { return msg.v }
 func (msg DictMsg) MarshalJSON() ([]byte, error) {
 	jsonData, err := json.Marshal(msg.v)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -277,7 +277,7 @@ func NewDictMsg(d map[string]Msg) DictMsg {
 
 // --- STRUCT ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type StructMsg struct {
 	internalMsg
 	fields []StructField
@@ -289,16 +289,16 @@ func (msg StructMsg) Struct() StructMsg { return msg }
 // it panics if the field is not found.
 // it uses linear scan to find the field.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (msg StructMsg) Get(name string) Msg { //nolint:ireturn,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
+//nolint:ireturn
+func (msg StructMsg) Get(name string) Msg { //nolint:ireturn,lll
 	if field, ok := msg.get(name); ok {
 		return field
 	}
 	panic(fmt.Sprintf("field %q not found", name))
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (msg StructMsg) get(name string) (Msg, bool) {
 	for i := range msg.fields {
 		if msg.fields[i].name == name {
@@ -316,7 +316,7 @@ func (msg StructMsg) MarshalJSON() ([]byte, error) {
 
 	jsonData, err := json.Marshal(m)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 
@@ -368,7 +368,7 @@ func newStructMsg(fields []StructField) StructMsg {
 
 // structfield is a helper to construct structs via runtime.newstruct api without exposing fields.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type StructField struct {
 	value Msg
 	name  string
@@ -376,7 +376,7 @@ type StructField struct {
 
 // newstructfield constructs a structfield with provided name and value.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func NewStructField(name string, value Msg) StructField {
 	return StructField{name: name, value: value}
 }
@@ -384,12 +384,12 @@ func NewStructField(name string, value Msg) StructField {
 // newstruct builds a struct message from a slice of structfield.
 // underlying struct representation remains unchanged for now.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func NewStructMsg(fields []StructField) StructMsg { return newStructMsg(fields) }
 
 // --- UNION ---
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 type UnionMsg struct {
 	internalMsg
 	data Msg
@@ -404,7 +404,7 @@ func (msg UnionMsg) Tag() string {
 	return msg.tag
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (msg UnionMsg) Data() Msg {
 	return msg.data
 }
@@ -424,7 +424,7 @@ func (msg UnionMsg) MarshalJSON() ([]byte, error) {
 
 	dataJSON, err := json.Marshal(msg.data)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	dataJSON = addJSONSpaces(dataJSON)
@@ -487,7 +487,7 @@ func NewUnionMsg(tag string, data Msg) UnionMsg {
 func Match(msg Msg, pattern Msg) bool {
 	// at the moment we only match unions
 	// maybe in the future we'll add support for more types e.g. structs
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	msgUnion, ok := msg.(UnionMsg)
 	if !ok {
 		return msg.Equal(pattern)
@@ -530,7 +530,7 @@ func addJSONSpaces(jsonData []byte) []byte {
 	inString := false
 	isEscaped := false
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for _, b := range jsonData {
 		if inString {
 			spaced = append(spaced, b)

--- a/internal/runtime/program.go
+++ b/internal/runtime/program.go
@@ -89,7 +89,7 @@ func NewSingleInport(
 	return &SingleInport{addr: addr, interceptor: interceptor, ch: ch}
 }
 
-//nolint:ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn
 func (s SingleInport) Receive(ctx context.Context) (Msg, bool) {
 	var msg Msg
 	select {
@@ -125,7 +125,7 @@ func (f Inports) Array(name string) (ArrayInport, error) {
 	return *ports.array, nil
 }
 
-//nolint:recvcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:recvcheck
 type ArrayInport struct {
 	addr        PortAddr
 	interceptor Interceptor
@@ -150,13 +150,13 @@ func NewArrayInport(
 // It returns the received message and a boolean indicating success.
 // It returns false if the context is done or if the channel is closed.
 //
-//nolint:gocritic,ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,ireturn
 func (a ArrayInport) Receive(ctx context.Context, idx int) (Msg, bool) {
 	select {
 	case <-ctx.Done():
 		return nil, false
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	case v := <-a.chans[idx]: //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
+	case v := <-a.chans[idx]: //nolint:varnamelen
 		index := Uint8Index(idx)
 		msg := a.interceptor.Received(
 			PortSlotAddr{
@@ -178,10 +178,10 @@ func (a ArrayInport) Receive(ctx context.Context, idx int) (Msg, bool) {
 // The function should return false if it wants to stop receiving messages.
 // Functions are called in order of incoming messages, not in order of slots.
 //
-//nolint:gocritic,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,varnamelen
 func (a ArrayInport) ReceiveAll(ctx context.Context, f func(idx int, msg Msg) bool) bool {
 	// IDEA return channel instead of taking function
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var wg sync.WaitGroup
 	success := true
 	resultChan := make(chan bool, len(a.chans))
@@ -235,7 +235,7 @@ func (s SelectedMsg) String() string {
 
 // Select returns the oldest
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a ArrayInport) _select(ctx context.Context) ([]SelectedMsg, bool) {
 	buf := make([]SelectedMsg, 0, len(a.chans)^2) // len(ss)^2 is an upper bound of messages that can be received
 
@@ -243,7 +243,7 @@ func (a ArrayInport) _select(ctx context.Context) ([]SelectedMsg, bool) {
 		// it's important to do at least len(ss) iterations even if we already got some messages
 		// the reason is that sending might happen exactly while skip iteration in default case
 		// if we do len(ss) iterations, that's ok, because we will go back and check
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		for slotIdx, ch := range a.chans {
 			select {
 			default:
@@ -296,7 +296,7 @@ func (a *ArrayInport) Select(ctx context.Context) (SelectedMsg, bool) {
 	return v, true
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (a ArrayInport) Len() int {
 	return len(a.chans)
 }
@@ -432,9 +432,9 @@ func (a ArrayOutport) Send(ctx context.Context, idx uint8, msg Msg) bool {
 // Each slot is guaranteed to be handled only once.
 // TODO: figure out why this is the only working version of `SendAll`
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func (a ArrayOutport) SendAll(ctx context.Context, msg Msg) bool {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var wg sync.WaitGroup
 	success := true
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -39,7 +39,7 @@ func Run(ctx context.Context, prog Program, registry map[string]FuncCreator) err
 // It sends the provided input to Start, waits for one message on Stop,
 // then cancels and waits for all handlers to finish.
 //
-//nolint:ireturn,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:ireturn,varnamelen
 func Call(ctx context.Context, prog Program, registry map[string]FuncCreator, in Msg) (Msg, error) {
 	var out Msg
 	ctx, cancel := context.WithCancel(ctx)
@@ -79,7 +79,7 @@ func deferFuncCalls(
 	}
 
 	return func(ctx context.Context) {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		wg := sync.WaitGroup{}
 		for i := range handlers {
 			routine := handlers[i]
@@ -97,7 +97,7 @@ func createHandlers(
 ) ([]func(context.Context), error) {
 	funcs := make([]func(context.Context), len(funcCalls))
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	for i, call := range funcCalls {
 		creator, ok := registry[call.Ref]
 		if !ok {

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -1,7 +1,7 @@
 // This package defines source code entities - abstractions that end-user (a programmer) operates on.
 // For convenience these structures have json tags. This is not clean architecture but it's very handy for LSP.
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 package ast
 
 import (
@@ -27,9 +27,9 @@ type Module struct {
 	Manifest ModuleManifest     `json:"manifest"`
 }
 
-//nolint:gocritic,nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,nonamedreturns
 func (mod Module) Entity(entityRef core.EntityRef) (entity Entity, filename string, err error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	pkg, ok := mod.Packages[entityRef.Pkg]
 	if !ok {
 		return Entity{}, "", fmt.Errorf("package not found: %v", entityRef.Pkg)
@@ -52,9 +52,9 @@ type Package map[string]File
 
 // Just like program's Entity
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (p Package) Entity(entityName string) (entity Entity, filename string, ok bool) { //nolint:lll,nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
+//nolint:nonamedreturns
+func (p Package) Entity(entityName string) (entity Entity, filename string, ok bool) { //nolint:lll,nonamedreturns
 	for fileName, file := range p {
 		entity, ok := file.Entities[entityName]
 		if ok {
@@ -74,7 +74,7 @@ type EntitiesResult struct {
 func (pkg Package) Entities() func(func(EntitiesResult) bool) {
 	return func(yield func(EntitiesResult) bool) {
 		for fileName, file := range pkg {
-			//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:gocritic
 			for entityName, entity := range file.Entities {
 				if !yield(EntitiesResult{
 					EntityName: entityName,
@@ -108,9 +108,9 @@ type Entity struct {
 	IsPublic  bool        `json:"exported,omitempty"`
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (e Entity) Meta() *core.Meta {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	m := core.Meta{}
 	switch e.Kind {
 	case ConstEntity:
@@ -163,10 +163,10 @@ type TypeParams struct {
 	Meta   core.Meta  `json:"meta"`
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (t TypeParams) ToFrame() map[string]ts.Def {
 	frame := make(map[string]ts.Def, len(t.Params))
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for _, param := range t.Params {
 		frame[param.Name] = ts.Def{
 			BodyExpr: &param.Constr,
@@ -177,10 +177,10 @@ func (t TypeParams) ToFrame() map[string]ts.Def {
 }
 
 func (t TypeParams) String() string {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var s strings.Builder
 	s.WriteString("<")
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, param := range t.Params {
 		s.WriteString(param.Name + " " + param.Constr.String())
 		if i < len(t.Params)-1 {
@@ -213,10 +213,10 @@ func (n Node) String() string {
 type TypeArgs []ts.Expr
 
 func (t TypeArgs) String() string {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var s strings.Builder
 	s.WriteString("<")
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	for i, arg := range t {
 		s.WriteString(arg.String())
 		if i < len(t)-1 {
@@ -267,20 +267,20 @@ type UnionLiteral struct {
 func (m MsgLiteral) String() string {
 	switch {
 	case m.Bool != nil:
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return fmt.Sprintf("%v", *m.Bool)
 	case m.Int != nil:
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return fmt.Sprintf("%v", *m.Int)
 	case m.Float != nil:
 		return fmt.Sprintf("%v", *m.Float)
 	case m.Str != nil:
 		return fmt.Sprintf("%q", *m.Str)
 	case len(m.List) != 0:
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		var s strings.Builder
 		s.WriteString("[")
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for i, item := range m.List {
 			s.WriteString(item.String())
 			if i != len(m.List)-1 {
@@ -289,10 +289,10 @@ func (m MsgLiteral) String() string {
 		}
 		return s.String() + "]"
 	case len(m.DictOrStruct) != 0:
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		var s strings.Builder
 		s.WriteString("{")
-		//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:gocritic
 		for key, value := range m.DictOrStruct {
 			fmt.Fprintf(&s, "%q: %v", key, value.String())
 		}
@@ -377,7 +377,7 @@ func (p PortAddr) String() string {
 		if IsArrayBypassIdx(p.Idx) {
 			idxString = "*"
 		} else {
-			//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:perfsprint
 			idxString = fmt.Sprintf("%v", *p.Idx)
 		}
 	}

--- a/pkg/ast/scope.go
+++ b/pkg/ast/scope.go
@@ -27,14 +27,14 @@ type Scope struct {
 
 // Location returns a location of the current scope
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) Location() *core.Location {
 	return &s.loc
 }
 
 // Relocate returns a new scope with a given location
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) Relocate(location core.Location) Scope {
 	return Scope{
 		loc:   location,
@@ -44,7 +44,7 @@ func (s Scope) Relocate(location core.Location) Scope {
 
 // IsTopType returns true if expr is a top type (any)
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) IsTopType(expr ts.Expr) bool {
 	if expr.Inst == nil {
 		return false
@@ -57,7 +57,7 @@ func (s Scope) IsTopType(expr ts.Expr) bool {
 
 // GetType returns type definition by reference
 //
-//nolint:gocritic,ireturn // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic,ireturn
 func (s Scope) GetType(ref core.EntityRef) (ts.Def, ts.Scope, error) {
 	entity, location, err := s.entity(ref)
 	if err != nil {
@@ -68,12 +68,12 @@ func (s Scope) GetType(ref core.EntityRef) (ts.Def, ts.Scope, error) {
 
 // Entity returns entity by reference
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) Entity(entityRef core.EntityRef) (Entity, core.Location, error) {
 	return s.entity(entityRef)
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) GetConst(entityRef core.EntityRef) (Const, core.Location, error) {
 	entity, loc, err := s.entity(entityRef)
 	if err != nil {
@@ -89,9 +89,9 @@ func (s Scope) GetConst(entityRef core.EntityRef) (Const, core.Location, error) 
 
 // TODO rename to GetComponents
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-func (s Scope) GetComponent(entityRef core.EntityRef) ([]Component, error) { //nolint:gocritic,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
+//nolint:gocritic
+func (s Scope) GetComponent(entityRef core.EntityRef) ([]Component, error) { //nolint:gocritic,lll
 	entity, _, err := s.entity(entityRef)
 	if err != nil {
 		return nil, err
@@ -106,9 +106,9 @@ func (s Scope) GetComponent(entityRef core.EntityRef) ([]Component, error) { //n
 
 // entity is an alrogithm that resolves entity reference based on scope's location
 //
-//nolint:cyclop,funlen,gocognit,gocritic,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:cyclop,funlen,gocognit,gocritic,gocyclo
 func (s Scope) entity(entityRef core.EntityRef) (Entity, core.Location, error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	curMod, ok := s.build.Modules[s.loc.ModRef]
 	if !ok {
 		return Entity{}, core.Location{}, fmt.Errorf("module not found: %v", s.loc.ModRef)
@@ -120,7 +120,7 @@ func (s Scope) entity(entityRef core.EntityRef) (Entity, core.Location, error) {
 	}
 
 	if entityRef.Pkg == "" { // local reference (current package or builtin)
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		entity, fileName, ok := curPkg.Entity(entityRef.Name)
 		if ok {
 			return entity, core.Location{
@@ -201,10 +201,10 @@ func (s Scope) entity(entityRef core.EntityRef) (Entity, core.Location, error) {
 	}, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) GetNodeIOByPortAddr(
 	nodes map[string]Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr PortAddr,
 ) (IO, error) {
 	node, ok := nodes[portAddr.Node]
@@ -230,10 +230,10 @@ func (s Scope) GetNodeIOByPortAddr(
 	return IO{}, errors.New("component not found")
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) GetFirstInportName(
 	nodes map[string]Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr PortAddr,
 ) (string, error) {
 	io, err := s.GetNodeIOByPortAddr(nodes, portAddr)
@@ -248,7 +248,7 @@ func (s Scope) GetFirstInportName(
 	return "", errors.New("first inport not found")
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) GetEntityKind(entityRef core.EntityRef) (EntityKind, error) {
 	entity, _, err := s.entity(entityRef)
 	if err != nil {
@@ -258,10 +258,10 @@ func (s Scope) GetEntityKind(entityRef core.EntityRef) (EntityKind, error) {
 	return entity.Kind, nil
 }
 
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (s Scope) GetFirstOutportName(
 	nodes map[string]Node,
-	//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:gocritic
 	portAddr PortAddr,
 ) (string, error) {
 	io, err := s.GetNodeIOByPortAddr(nodes, portAddr)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -39,7 +39,7 @@ type Location struct {
 }
 
 func (l Location) String() string {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	var s string
 	if l.ModRef.Path == "@" {
 		s = l.Package

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -65,7 +65,7 @@ func WithTimeout(timeout time.Duration) Option {
 // Most tests can ignore stderr: `out, _ := e2e.Run(...)`
 // Tests that need stderr (e.g., panic cases) can use: `out, stderr := e2e.Run(...)` and combine if needed.
 //
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func Run(t *testing.T, args []string, opts ...Option) (stdout, stderr string) {
 	t.Helper()
 
@@ -95,7 +95,7 @@ func Run(t *testing.T, args []string, opts ...Option) (stdout, stderr string) {
 	// Resolve the working directory from which the CLI should be executed.
 	// This intentionally differs from the directory used to build the CLI,
 	// which must stay at repo root so Go modules resolve correctly.
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	wd := cfg.wd
 	var err error
 	if wd == "" {
@@ -177,7 +177,7 @@ func FindRepoRoot(tb testing.TB) string {
 	tb.Helper()
 
 	// #nosec G204 -- command arguments are constant
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	cmd := exec.Command("go", "env", "GOMOD")
 	output, err := cmd.Output()
 	require.NoError(tb, err, "failed to run 'go env GOMOD'")
@@ -203,7 +203,7 @@ func BuildNevaBinary(tb testing.TB, repoRoot string) string {
 func PrepareIsolatedNevaHome(repoRoot, homeDir string) error {
 	nevaHome := filepath.Join(homeDir, "neva")
 	if err := os.MkdirAll(nevaHome, 0o755); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
@@ -213,7 +213,7 @@ func PrepareIsolatedNevaHome(repoRoot, homeDir string) error {
 		return nil
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return nevaos.CopyDir(stdSrc, stdDst)
 }
 
@@ -256,7 +256,7 @@ func buildNevaBinaryPerTest(tb testing.TB, repoRoot, mainPath string) string {
 	tb.Helper()
 
 	binPath := filepath.Join(tb.TempDir(), "neva")
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	buildCmd := exec.Command("go", "build", "-o", binPath, mainPath)
 	buildCmd.Dir = repoRoot
 
@@ -326,7 +326,7 @@ func buildNevaBinaryFromCache(repoRoot, mainPath string) (string, error) {
 
 // buildNevaBinaryToPath compiles cmd/neva into the requested output path.
 func buildNevaBinaryToPath(repoRoot, mainPath, binPath string) error {
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	buildCmd := exec.Command("go", "build", "-o", binPath, mainPath)
 	buildCmd.Dir = repoRoot
 
@@ -395,11 +395,11 @@ func nevaBuildFingerprint(repoRoot string) (string, error) {
 // compilerInputFiles returns local files that can affect `go build ./cmd/neva`.
 // It includes only repo-local package files from `go list -deps -json` plus go.mod/go.sum.
 //
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func compilerInputFiles(repoRoot string) ([]string, error) {
 	// Use package metadata to include only files that affect cmd/neva build.
 	// External module changes are already covered by go.mod/go.sum.
-	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:noctx
 	cmd := exec.Command("go", "list", "-deps", "-json", "./cmd/neva")
 	cmd.Dir = repoRoot
 
@@ -472,7 +472,7 @@ func addPackageFiles(filesSet map[string]struct{}, dir string, names []string) {
 
 // decodePackageDir extracts package directory info and filters out stdlib/external packages.
 //
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func decodePackageDir(payload map[string]json.RawMessage, normalizedRoot string) (dir string, include bool, err error) {
 	standard := false
 	if raw, ok := payload["Standard"]; ok && len(raw) > 0 {

--- a/pkg/e2e/process_unix.go
+++ b/pkg/e2e/process_unix.go
@@ -24,7 +24,7 @@ func configureCommandCleanup(cmd *exec.Cmd) {
 			return nil
 		}
 
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,7 +13,7 @@ import (
 // name, a tag, or any revision string understood by go-git's ResolveRevision.
 func Checkout(repo *gitlib.Repository, revision string) error {
 	if revision == "" {
-		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:perfsprint
 		return fmt.Errorf("revision must not be empty")
 	}
 

--- a/pkg/git/spec_test.go
+++ b/pkg/git/spec_test.go
@@ -2,7 +2,7 @@ package git
 
 import "testing"
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func TestParseRepoSpec(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/golang/mod.go
+++ b/pkg/golang/mod.go
@@ -8,24 +8,24 @@ import (
 	"strings"
 )
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func FindModulePath(dst string) (string, error) {
 	absDst, err := filepath.Abs(dst)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return "", err
 	}
 
 	dir := absDst
 	for {
 		goModPath := filepath.Join(dir, "go.mod")
-		//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:nestif
 		if _, err := os.Stat(goModPath); err == nil {
 			modulePath, err := func() (string, error) {
-				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+				//nolint:varnamelen
 				f, err := os.Open(goModPath)
 				if err != nil {
-					//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+					//nolint:wrapcheck
 					return "", err
 				}
 				defer f.Close()
@@ -37,7 +37,7 @@ func FindModulePath(dst string) (string, error) {
 						modName := strings.TrimSpace(after)
 						relPath, err := filepath.Rel(dir, absDst)
 						if err != nil {
-							//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+							//nolint:wrapcheck
 							return "", err
 						}
 						if relPath == "." {

--- a/pkg/indexer/default.go
+++ b/pkg/indexer/default.go
@@ -11,17 +11,17 @@ import (
 
 // NewDefault creates an Indexer with default compiler frontend dependencies.
 func NewDefault(logger commonlog.Logger) (Indexer, error) {
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	p := parser.New()
 
 	terminator := typesystem.Terminator{}
 	checker := typesystem.MustNewSubtypeChecker(terminator)
 	resolver := typesystem.MustNewResolver(typesystem.Validator{}, checker, terminator)
 
-	//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen
 	b, err := builder.New(p)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return Indexer{}, err
 	}
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -23,7 +23,7 @@ type Indexer struct {
 
 // FullScan processes and analyzes a Neva workspace.
 //
-//nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocritic
 func (i Indexer) FullScan(
 	ctx context.Context,
 	workspacePath string,

--- a/pkg/os/checksum.go
+++ b/pkg/os/checksum.go
@@ -34,7 +34,7 @@ func ComputeChecksumForFS(filesys fs.FS) (string, error) {
 	// Second pass: hash file contents
 	hasher := sha256.New()
 	for _, filename := range filenames {
-		//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:varnamelen
 		f, err := filesys.Open(filename)
 		if err != nil {
 			return "", fmt.Errorf("open %s: %w", filename, err)

--- a/pkg/os/checksum_test.go
+++ b/pkg/os/checksum_test.go
@@ -8,7 +8,7 @@ import (
 	"testing/fstest"
 )
 
-//nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:gocognit
 func TestComputeChecksumForFS(t *testing.T) {
 	tests := []struct {
 		setup       func(t *testing.T) fs.FS
@@ -117,7 +117,7 @@ type failingFS struct {
 func (f *failingFS) Open(name string) (fs.File, error) {
 	file, err := f.MapFS.Open(name)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return nil, err
 	}
 	return &failingFile{File: file}, nil
@@ -127,12 +127,12 @@ type failingFile struct {
 	fs.File
 }
 
-//nolint:nonamedreturns // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:nonamedreturns
 func (f *failingFile) Read(p []byte) (n int, err error) {
 	return 0, errors.New("read error")
 }
 
 func (f *failingFile) Stat() (fs.FileInfo, error) {
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return f.File.Stat()
 }

--- a/pkg/os/copy.go
+++ b/pkg/os/copy.go
@@ -9,39 +9,39 @@ import (
 
 // use the original permission bits so the copy matches the template file
 //
-//nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+//nolint:godoclint
 func CopyFile(src, dst string, mode fs.FileMode) error {
 	if err := stdos.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
 	srcFile, err := stdos.Open(src)
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	defer srcFile.Close()
 
 	dstFile, err := stdos.OpenFile(dst, stdos.O_CREATE|stdos.O_WRONLY|stdos.O_TRUNC, mode.Perm())
 	if err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 	defer func() { _ = dstFile.Close() }()
 
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+		//nolint:wrapcheck
 		return err
 	}
 
-	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:wrapcheck
 	return dstFile.Close()
 }
 
 // CopyDir recursively copies a directory tree preserving file modes.
 func CopyDir(src, dst string) error {
-	//nolint:varnamelen,wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+	//nolint:varnamelen,wrapcheck
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -49,7 +49,7 @@ func CopyDir(src, dst string) error {
 
 		rel, relErr := filepath.Rel(src, path)
 		if relErr != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return relErr
 		}
 
@@ -60,7 +60,7 @@ func CopyDir(src, dst string) error {
 
 		info, statErr := d.Info()
 		if statErr != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return statErr
 		}
 

--- a/pkg/os/write.go
+++ b/pkg/os/write.go
@@ -11,13 +11,13 @@ func SaveFilesToDir(dst string, files map[string][]byte) error {
 		dirPath := filepath.Dir(filePath)
 
 		if err := os.MkdirAll(dirPath, 0o755); err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 
 		// #nosec G306 -- build outputs are intended to be readable
 		if err := os.WriteFile(filePath, content, 0o644); err != nil {
-			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
+			//nolint:wrapcheck
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- remove the temporary strict-phase suffix from `//nolint:` comments across Go files
- keep existing `nolint` directives intact while deleting only the stale `TODO(strict-lint phase 1)` marker
- run `gofmt` on all touched files

## Validation
- `make lint`
- `go test ./internal/compiler/... ./internal/runtime/... ./pkg/... ./benchmarks/...`
