### PR TITLE
ci(lint): rename golangci check and set explicit config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           git diff --exit-code
 
   golangci:
-    name: lint
+    name: golangci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -38,6 +38,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          args: --config=.golangci.yml
 
   govulncheck:
     name: govulncheck


### PR DESCRIPTION
## Summary
- rename the golangci job display name from `lint` to `golangci` in `.github/workflows/lint.yml`
- this changes the check label from `lint / lint` to `lint / golangci` for clearer status context alongside `lint / govulncheck`
- pass explicit golangci config path (`--config=.golangci.yml`) in the action

## Notes
- `.golangci.yml` is unchanged
- existing `//nolint:... // TODO(strict-lint phase 1)` comments are preserved
