### PR TITLE
refactor(runtime): centralize runtime func port lookups

### DIFF
--- a/internal/runtime/funcs/accumulator.go
+++ b/internal/runtime/funcs/accumulator.go
@@ -11,31 +11,31 @@ type accumulator struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (a accumulator) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	initIn, err := io.In.Single("init")
+	initIn, err := singleIn(io, "init")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	updIn, err := io.In.Single("upd")
+	updIn, err := singleIn(io, "upd")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	lastIn, err := io.In.Single("last")
+	lastIn, err := singleIn(io, "last")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	curOut, err := io.Out.Single("cur")
+	curOut, err := singleOut(io, "cur")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/and.go
+++ b/internal/runtime/funcs/and.go
@@ -11,19 +11,19 @@ type and struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p and) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	aIn, err := io.In.Single("left")
+	aIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	bIn, err := io.In.Single("right")
+	bIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/args.go
+++ b/internal/runtime/funcs/args.go
@@ -11,13 +11,13 @@ type args struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (a args) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	sigIn, err := io.In.Single("sig")
+	sigIn, err := singleIn(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/arr_port_to_list.go
+++ b/internal/runtime/funcs/arr_port_to_list.go
@@ -14,12 +14,12 @@ func (arrayPortToList) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(context.Context), error) {
-	portIn, err := io.In.Array("port")
+	portIn, err := arrayIn(io, "port")
 	if err != nil {
 		return nil, errors.New("missing array inport 'port'")
 	}
 
-	listOut, err := io.Out.Single("res")
+	listOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/arr_port_to_stream.go
+++ b/internal/runtime/funcs/arr_port_to_stream.go
@@ -14,12 +14,12 @@ func (arrayPortToStream) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(context.Context), error) {
-	portIn, err := io.In.Array("port")
+	portIn, err := arrayIn(io, "port")
 	if err != nil {
 		return nil, errors.New("missing array inport 'port'")
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/atoi.go
+++ b/internal/runtime/funcs/atoi.go
@@ -13,19 +13,19 @@ type atoi struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (a atoi) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/bytes_from_string.go
+++ b/internal/runtime/funcs/bytes_from_string.go
@@ -10,13 +10,13 @@ type bytesFromString struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (bytesFromString) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/cond.go
+++ b/internal/runtime/funcs/cond.go
@@ -11,25 +11,25 @@ type cond struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (c cond) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	ifIn, err := io.In.Single("if")
+	ifIn, err := singleIn(io, "if")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	thenOut, err := io.Out.Single("then")
+	thenOut, err := singleOut(io, "then")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elseOut, err := io.Out.Single("else")
+	elseOut, err := singleOut(io, "else")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/del.go
+++ b/internal/runtime/funcs/del.go
@@ -9,7 +9,7 @@ import (
 type del struct{}
 
 func (d del) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/dict_to_stream.go
+++ b/internal/runtime/funcs/dict_to_stream.go
@@ -13,13 +13,13 @@ func (dictToStream) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/dotenv_load.go
+++ b/internal/runtime/funcs/dotenv_load.go
@@ -23,19 +23,19 @@ type dotenvLoad struct {
 
 //nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (d dotenvLoadFrom) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	filenameIn, err := rio.In.Single("data")
+	filenameIn, err := singleIn(rio, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := rio.Out.Single("res")
+	resOut, err := singleOut(rio, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := rio.Out.Single("err")
+	errOut, err := singleOut(rio, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
@@ -69,19 +69,19 @@ func (d dotenvLoadFrom) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.
 
 //nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (d dotenvLoad) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	sigIn, err := rio.In.Single("sig")
+	sigIn, err := singleIn(rio, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := rio.Out.Single("res")
+	resOut, err := singleOut(rio, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := rio.Out.Single("err")
+	errOut, err := singleOut(rio, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/eq.go
+++ b/internal/runtime/funcs/eq.go
@@ -11,19 +11,19 @@ type eq struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p eq) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/errors_new.go
+++ b/internal/runtime/funcs/errors_new.go
@@ -13,13 +13,13 @@ func (errorsNew) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/fan_in.go
+++ b/internal/runtime/funcs/fan_in.go
@@ -10,13 +10,13 @@ type fanIn struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (fanIn) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	data, err := io.In.Array("data")
+	data, err := arrayIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/fan_out.go
+++ b/internal/runtime/funcs/fan_out.go
@@ -10,13 +10,13 @@ type fanOut struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (d fanOut) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	dataOut, err := io.Out.Array("data")
+	dataOut, err := arrayOut(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/field.go
+++ b/internal/runtime/funcs/field.go
@@ -21,13 +21,13 @@ func (s structField) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Co
 		pathStrings = append(pathStrings, el.Str())
 	}
 
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/file_read_all.go
+++ b/internal/runtime/funcs/file_read_all.go
@@ -12,19 +12,19 @@ type fileReadAll struct{}
 
 //nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (c fileReadAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	filenameIn, err := rio.In.Single("filename")
+	filenameIn, err := singleIn(rio, "filename")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := rio.Out.Single("res")
+	resOut, err := singleOut(rio, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := rio.Out.Single("err")
+	errOut, err := singleOut(rio, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_add.go
+++ b/internal/runtime/funcs/float_add.go
@@ -15,19 +15,19 @@ func (floatAdd) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_div.go
+++ b/internal/runtime/funcs/float_div.go
@@ -15,19 +15,19 @@ func (floatDiv) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_from_int.go
+++ b/internal/runtime/funcs/float_from_int.go
@@ -13,13 +13,13 @@ func (floatFromInt) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_is_greater.go
+++ b/internal/runtime/funcs/float_is_greater.go
@@ -11,19 +11,19 @@ type floatIsGreater struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p floatIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_is_lesser.go
+++ b/internal/runtime/funcs/float_is_lesser.go
@@ -11,19 +11,19 @@ type floatIsLesser struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p floatIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_mul.go
+++ b/internal/runtime/funcs/float_mul.go
@@ -15,19 +15,19 @@ func (floatMul) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_neg.go
+++ b/internal/runtime/funcs/float_neg.go
@@ -10,13 +10,13 @@ type floatNeg struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (floatNeg) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/float_sub.go
+++ b/internal/runtime/funcs/float_sub.go
@@ -15,19 +15,19 @@ func (floatSub) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	leftIn, err := io.In.Single("left")
+	leftIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	rightIn, err := io.In.Single("right")
+	rightIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/format_bool.go
+++ b/internal/runtime/funcs/format_bool.go
@@ -14,13 +14,13 @@ func (formatBool) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/format_float.go
+++ b/internal/runtime/funcs/format_float.go
@@ -15,31 +15,31 @@ func (formatFloat) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	fmtIn, err := io.In.Single("fmt")
+	fmtIn, err := singleIn(io, "fmt")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	precIn, err := io.In.Single("prec")
+	precIn, err := singleIn(io, "prec")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	bitsIn, err := io.In.Single("bits")
+	bitsIn, err := singleIn(io, "bits")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/format_int.go
+++ b/internal/runtime/funcs/format_int.go
@@ -14,19 +14,19 @@ func (formatInt) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	baseIn, err := io.In.Single("base")
+	baseIn, err := singleIn(io, "base")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/get.go
+++ b/internal/runtime/funcs/get.go
@@ -11,25 +11,25 @@ type getDictValue struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (g getDictValue) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dictIn, err := io.In.Single("dict")
+	dictIn, err := singleIn(io, "dict")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	keyIn, err := io.In.Single("key")
+	keyIn, err := singleIn(io, "key")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/http.go
+++ b/internal/runtime/funcs/http.go
@@ -12,19 +12,19 @@ type httpGet struct{}
 
 //nolint:cyclop,gocognit,gocyclo // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (httpGet) Create(funcIO runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	urlIn, err := funcIO.In.Single("url")
+	urlIn, err := singleIn(funcIO, "url")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := funcIO.Out.Single("res")
+	resOut, err := singleOut(funcIO, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := funcIO.Out.Single("err")
+	errOut, err := singleOut(funcIO, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/image_encode.go
+++ b/internal/runtime/funcs/image_encode.go
@@ -12,19 +12,19 @@ type imageEncode struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (imageEncode) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	imgIn, err := io.In.Single("img")
+	imgIn, err := singleIn(io, "img")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/image_new.go
+++ b/internal/runtime/funcs/image_new.go
@@ -11,19 +11,19 @@ type imageNew struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (imageNew) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	pixelsIn, err := io.In.Single("pixels")
+	pixelsIn, err := singleIn(io, "pixels")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	imgOut, err := io.Out.Single("img")
+	imgOut, err := singleOut(io, "img")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_add.go
+++ b/internal/runtime/funcs/int_add.go
@@ -15,19 +15,19 @@ func (intAdd) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_bitwise_and.go
+++ b/internal/runtime/funcs/int_bitwise_and.go
@@ -15,19 +15,19 @@ func (intBitwiseAnd) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_bitwise_lsh.go
+++ b/internal/runtime/funcs/int_bitwise_lsh.go
@@ -15,19 +15,19 @@ func (intBitwiseLsh) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_bitwise_or.go
+++ b/internal/runtime/funcs/int_bitwise_or.go
@@ -15,19 +15,19 @@ func (intBitwiseOr) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_bitwise_rsh.go
+++ b/internal/runtime/funcs/int_bitwise_rsh.go
@@ -15,19 +15,19 @@ func (intBitwiseRsh) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_bitwise_xor.go
+++ b/internal/runtime/funcs/int_bitwise_xor.go
@@ -15,19 +15,19 @@ func (intBitwiseXor) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_decr.go
+++ b/internal/runtime/funcs/int_decr.go
@@ -10,13 +10,13 @@ type intDec struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (i intDec) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_div.go
+++ b/internal/runtime/funcs/int_div.go
@@ -15,19 +15,19 @@ func (intDiv) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_from_float.go
+++ b/internal/runtime/funcs/int_from_float.go
@@ -13,13 +13,13 @@ func (intFromFloat) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_inc.go
+++ b/internal/runtime/funcs/int_inc.go
@@ -10,13 +10,13 @@ type intInc struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (i intInc) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_is_greater.go
+++ b/internal/runtime/funcs/int_is_greater.go
@@ -11,19 +11,19 @@ type intIsGreater struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p intIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_is_greater_or_equal.go
+++ b/internal/runtime/funcs/int_is_greater_or_equal.go
@@ -15,19 +15,19 @@ func (intIsGreaterOrEqual) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_is_lesser.go
+++ b/internal/runtime/funcs/int_is_lesser.go
@@ -11,19 +11,19 @@ type intIsLesser struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p intIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_is_lesser_or_equal.go
+++ b/internal/runtime/funcs/int_is_lesser_or_equal.go
@@ -15,19 +15,19 @@ func (intIsLesserOrEqual) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_mod.go
+++ b/internal/runtime/funcs/int_mod.go
@@ -10,19 +10,19 @@ type intMod struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (intMod) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	leftIn, err := io.In.Single("left") // numerator
+	leftIn, err := singleIn(io, "left") // numerator
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	denIn, err := io.In.Single("right") // denominator
+	denIn, err := singleIn(io, "right") // denominator
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res") // modulo
+	resOut, err := singleOut(io, "res") // modulo
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_mul.go
+++ b/internal/runtime/funcs/int_mul.go
@@ -15,19 +15,19 @@ func (intMul) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_neg.go
+++ b/internal/runtime/funcs/int_neg.go
@@ -10,13 +10,13 @@ type intNeg struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (intNeg) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_pow.go
+++ b/internal/runtime/funcs/int_pow.go
@@ -14,19 +14,19 @@ func (intPow) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/int_sub.go
+++ b/internal/runtime/funcs/int_sub.go
@@ -15,19 +15,19 @@ func (intSub) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	accIn, err := io.In.Single("left")
+	accIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elIn, err := io.In.Single("right")
+	elIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/itoa.go
+++ b/internal/runtime/funcs/itoa.go
@@ -14,13 +14,13 @@ func (itoa) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/list_at.go
+++ b/internal/runtime/funcs/list_at.go
@@ -10,25 +10,25 @@ type listAt struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (listAt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	idxIn, err := io.In.Single("idx")
+	idxIn, err := singleIn(io, "idx")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/list_len.go
+++ b/internal/runtime/funcs/list_len.go
@@ -10,13 +10,13 @@ type listlen struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p listlen) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/list_push.go
+++ b/internal/runtime/funcs/list_push.go
@@ -11,18 +11,18 @@ type listPush struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p listPush) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
-	lstIn, err := io.In.Single("lst")
+	lstIn, err := singleIn(io, "lst")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/list_slice.go
+++ b/internal/runtime/funcs/list_slice.go
@@ -17,25 +17,25 @@ func sliceList(data []runtime.Msg, from int64, to int64) []runtime.Msg {
 
 //nolint:dupl,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (listSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	fromIn, err := io.In.Single("from")
+	fromIn, err := singleIn(io, "from")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	toIn, err := io.In.Single("to")
+	toIn, err := singleIn(io, "to")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/list_to_stream.go
+++ b/internal/runtime/funcs/list_to_stream.go
@@ -13,13 +13,13 @@ func (c listToStream) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/lock.go
+++ b/internal/runtime/funcs/lock.go
@@ -11,19 +11,19 @@ type lock struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (l lock) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	sigIn, err := io.In.Single("sig")
+	sigIn, err := singleIn(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/match.go
+++ b/internal/runtime/funcs/match.go
@@ -11,19 +11,19 @@ type matchSelector struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (matchSelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	ifIn, err := io.In.Array("if")
+	ifIn, err := arrayIn(io, "if")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	thenOut, err := io.In.Array("then")
+	thenOut, err := arrayIn(io, "then")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
@@ -33,13 +33,13 @@ func (matchSelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Cont
 		return nil, errors.New("number of 'if' inports must match number of 'then' outports")
 	}
 
-	elseIn, err := io.In.Single("else")
+	elseIn, err := singleIn(io, "else")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/ne.go
+++ b/internal/runtime/funcs/ne.go
@@ -11,19 +11,19 @@ type notEq struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p notEq) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/new.go
+++ b/internal/runtime/funcs/new.go
@@ -10,13 +10,13 @@ type newV2 struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (c newV2) Create(io runtime.IO, cfg runtime.Msg) (func(ctx context.Context), error) {
-	sigIn, err := io.In.Single("sig")
+	sigIn, err := singleIn(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/not.go
+++ b/internal/runtime/funcs/not.go
@@ -10,12 +10,12 @@ type not struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p not) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/or.go
+++ b/internal/runtime/funcs/or.go
@@ -11,19 +11,19 @@ type or struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p or) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	aIn, err := io.In.Single("left")
+	aIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	bIn, err := io.In.Single("right")
+	bIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/os_environ.go
+++ b/internal/runtime/funcs/os_environ.go
@@ -11,13 +11,13 @@ type osEnviron struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (o osEnviron) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	sigIn, err := io.In.Single("sig")
+	sigIn, err := singleIn(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/panic.go
+++ b/internal/runtime/funcs/panic.go
@@ -14,7 +14,7 @@ func (p panicker) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	msgIn, err := io.In.Single("data")
+	msgIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/parse_bool.go
+++ b/internal/runtime/funcs/parse_bool.go
@@ -16,19 +16,19 @@ func (parseBool) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/parse_float.go
+++ b/internal/runtime/funcs/parse_float.go
@@ -13,25 +13,25 @@ type parseFloat struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p parseFloat) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	bitsIn, err := io.In.Single("bits")
+	bitsIn, err := singleIn(io, "bits")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/parse_int.go
+++ b/internal/runtime/funcs/parse_int.go
@@ -13,31 +13,31 @@ type parseInt struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p parseInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	baseIn, err := io.In.Single("base")
+	baseIn, err := singleIn(io, "base")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	bitsIn, err := io.In.Single("bits")
+	bitsIn, err := singleIn(io, "bits")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/ports.go
+++ b/internal/runtime/funcs/ports.go
@@ -1,0 +1,39 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/nevalang/neva/internal/runtime"
+)
+
+func singleIn(runtimeIO runtime.IO, portName string) (runtime.SingleInport, error) {
+	port, err := runtimeIO.In.Single(portName)
+	if err != nil {
+		return runtime.SingleInport{}, fmt.Errorf("input %q: %w", portName, err)
+	}
+	return port, nil
+}
+
+func arrayIn(runtimeIO runtime.IO, portName string) (runtime.ArrayInport, error) {
+	port, err := runtimeIO.In.Array(portName)
+	if err != nil {
+		return runtime.ArrayInport{}, fmt.Errorf("input %q: %w", portName, err)
+	}
+	return port, nil
+}
+
+func singleOut(runtimeIO runtime.IO, portName string) (runtime.SingleOutport, error) {
+	port, err := runtimeIO.Out.Single(portName)
+	if err != nil {
+		return runtime.SingleOutport{}, fmt.Errorf("output %q: %w", portName, err)
+	}
+	return port, nil
+}
+
+func arrayOut(runtimeIO runtime.IO, portName string) (runtime.ArrayOutport, error) {
+	port, err := runtimeIO.Out.Array(portName)
+	if err != nil {
+		return runtime.ArrayOutport{}, fmt.Errorf("output %q: %w", portName, err)
+	}
+	return port, nil
+}

--- a/internal/runtime/funcs/print.go
+++ b/internal/runtime/funcs/print.go
@@ -12,19 +12,19 @@ type printFunc struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (printFunc) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/printf.go
+++ b/internal/runtime/funcs/printf.go
@@ -13,25 +13,25 @@ type printf struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p printf) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	tplIn, err := io.In.Single("tpl")
+	tplIn, err := singleIn(io, "tpl")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	argsIn, err := io.In.Array("args")
+	argsIn, err := arrayIn(io, "args")
 	if err != nil {
 		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, fmt.Errorf("missing required input port 'args'")
 	}
 
-	sigOut, err := io.Out.Single("sig")
+	sigOut, err := singleOut(io, "sig")
 	if err != nil {
 		//nolint:perfsprint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, fmt.Errorf("missing required output port 'args'")
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/println.go
+++ b/internal/runtime/funcs/println.go
@@ -12,19 +12,19 @@ type printlnFunc struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (printlnFunc) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/race.go
+++ b/internal/runtime/funcs/race.go
@@ -12,19 +12,19 @@ type race struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (race) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	casesArrIn, err := io.In.Array("case")
+	casesArrIn, err := arrayIn(io, "case")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	casesOut, err := io.Out.Array("case")
+	casesOut, err := arrayOut(io, "case")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/range_int.go
+++ b/internal/runtime/funcs/range_int.go
@@ -10,19 +10,19 @@ type rangeInt struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	fromIn, err := io.In.Single("from")
+	fromIn, err := singleIn(io, "from")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	toIn, err := io.In.Single("to")
+	toIn, err := singleIn(io, "to")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/regexp_submatch.go
+++ b/internal/runtime/funcs/regexp_submatch.go
@@ -12,25 +12,25 @@ type regexpSubmatch struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (r regexpSubmatch) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	regexpIn, err := io.In.Single("regexp")
+	regexpIn, err := singleIn(io, "regexp")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/scanln.go
+++ b/internal/runtime/funcs/scanln.go
@@ -14,19 +14,19 @@ type scanln struct{}
 //nolint:godoclint // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 //nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (r scanln) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) { //nolint:gocognit,lll // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	sigIn, err := rio.In.Single("sig")
+	sigIn, err := singleIn(rio, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := rio.Out.Single("res")
+	resOut, err := singleOut(rio, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := rio.Out.Single("err")
+	errOut, err := singleOut(rio, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/select.go
+++ b/internal/runtime/funcs/select.go
@@ -11,13 +11,13 @@ type selector struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (selector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	ifArrIn, err := io.In.Array("if")
+	ifArrIn, err := arrayIn(io, "if")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	thenArrIn, err := io.In.Array("then")
+	thenArrIn, err := arrayIn(io, "then")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
@@ -27,7 +27,7 @@ func (selector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 		return nil, errors.New("number of 'if' inports must match number of 'then' outports")
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/stream_product.go
+++ b/internal/runtime/funcs/stream_product.go
@@ -15,19 +15,19 @@ func (streamProduct) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	firstIn, err := io.In.Single("first")
+	firstIn, err := singleIn(io, "first")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	secondIn, err := io.In.Single("second")
+	secondIn, err := singleIn(io, "second")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/stream_to_dict.go
+++ b/internal/runtime/funcs/stream_to_dict.go
@@ -13,13 +13,13 @@ func (streamToDict) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/stream_to_list.go
+++ b/internal/runtime/funcs/stream_to_list.go
@@ -13,13 +13,13 @@ func (s streamToList) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	seqIn, err := io.In.Single("data")
+	seqIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/stream_zip.go
+++ b/internal/runtime/funcs/stream_zip.go
@@ -14,19 +14,19 @@ func (streamZip) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	leftIn, err := io.In.Single("left")
+	leftIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	rightIn, err := io.In.Single("right")
+	rightIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/stream_zip_many.go
+++ b/internal/runtime/funcs/stream_zip_many.go
@@ -16,13 +16,13 @@ func (streamZipMany) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Array("data")
+	dataIn, err := arrayIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_add.go
+++ b/internal/runtime/funcs/string_add.go
@@ -15,19 +15,19 @@ func (stringAdd) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	leftIn, err := io.In.Single("left")
+	leftIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	rightIn, err := io.In.Single("right")
+	rightIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_at.go
+++ b/internal/runtime/funcs/string_at.go
@@ -11,25 +11,25 @@ type stringAt struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (stringAt) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	idxIn, err := io.In.Single("idx")
+	idxIn, err := singleIn(io, "idx")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := io.Out.Single("err")
+	errOut, err := singleOut(io, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_from_int_codepoint.go
+++ b/internal/runtime/funcs/string_from_int_codepoint.go
@@ -14,13 +14,13 @@ func (stringFromIntCodepoint) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_is_greater.go
+++ b/internal/runtime/funcs/string_is_greater.go
@@ -11,19 +11,19 @@ type strIsGreater struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p strIsGreater) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_is_lesser.go
+++ b/internal/runtime/funcs/string_is_lesser.go
@@ -11,19 +11,19 @@ type strIsLesser struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p strIsLesser) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	actualIn, err := io.In.Single("left")
+	actualIn, err := singleIn(io, "left")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	comparedIn, err := io.In.Single("right")
+	comparedIn, err := singleIn(io, "right")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_join.go
+++ b/internal/runtime/funcs/string_join.go
@@ -11,19 +11,19 @@ type stringJoinList struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (stringJoinList) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	sepIn, err := io.In.Single("sep")
+	sepIn, err := singleIn(io, "sep")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
@@ -64,19 +64,19 @@ type stringJoinStream struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (stringJoinStream) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	sepIn, err := io.In.Single("sep")
+	sepIn, err := singleIn(io, "sep")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_slice.go
+++ b/internal/runtime/funcs/string_slice.go
@@ -18,25 +18,25 @@ func sliceString(data string, from int64, to int64) string {
 
 //nolint:dupl,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (stringSlice) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	fromIn, err := io.In.Single("from")
+	fromIn, err := singleIn(io, "from")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	toIn, err := io.In.Single("to")
+	toIn, err := singleIn(io, "to")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_split.go
+++ b/internal/runtime/funcs/string_split.go
@@ -11,19 +11,19 @@ type stringsSplit struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p stringsSplit) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	delimIn, err := io.In.Single("delim")
+	delimIn, err := singleIn(io, "delim")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/string_to_stream.go
+++ b/internal/runtime/funcs/string_to_stream.go
@@ -13,13 +13,13 @@ func (stringToStream) Create(
 	io runtime.IO,
 	_ runtime.Msg,
 ) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/strings_from_bytes.go
+++ b/internal/runtime/funcs/strings_from_bytes.go
@@ -10,13 +10,13 @@ type stringsFromBytes struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (stringsFromBytes) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/strings_to_lower.go
+++ b/internal/runtime/funcs/strings_to_lower.go
@@ -11,13 +11,13 @@ type stringsToLower struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p stringsToLower) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/strings_to_upper.go
+++ b/internal/runtime/funcs/strings_to_upper.go
@@ -11,13 +11,13 @@ type stringsToUpper struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p stringsToUpper) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/struct.go
+++ b/internal/runtime/funcs/struct.go
@@ -27,7 +27,7 @@ func (s structBuilder) Create(
 		inports[inportName] = *inportSlots.Single()
 	}
 
-	outport, err := io.Out.Single("res")
+	outport, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/switch.go
+++ b/internal/runtime/funcs/switch.go
@@ -12,25 +12,25 @@ type switchRouter struct{}
 
 //nolint:cyclop,gocognit,gocyclo,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (switchRouter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	caseArrIn, err := io.In.Array("case")
+	caseArrIn, err := arrayIn(io, "case")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	caseOut, err := io.Out.Array("case")
+	caseOut, err := arrayOut(io, "case")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elseOut, err := io.Out.Single("else")
+	elseOut, err := singleOut(io, "else")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/ternary.go
+++ b/internal/runtime/funcs/ternary.go
@@ -10,25 +10,25 @@ type ternarySelector struct{}
 
 //nolint:gocognit,varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (p ternarySelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	ifIn, err := io.In.Single("if")
+	ifIn, err := singleIn(io, "if")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	thenIn, err := io.In.Single("then")
+	thenIn, err := singleIn(io, "then")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	elseIn, err := io.In.Single("else")
+	elseIn, err := singleIn(io, "else")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/time_delay.go
+++ b/internal/runtime/funcs/time_delay.go
@@ -11,19 +11,19 @@ type timeDelay struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (timeDelay) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	durIn, err := io.In.Single("dur")
+	durIn, err := singleIn(io, "dur")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/time_sleep.go
+++ b/internal/runtime/funcs/time_sleep.go
@@ -11,13 +11,13 @@ type timeAfter struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (timeAfter) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	durIn, err := io.In.Single("dur")
+	durIn, err := singleIn(io, "dur")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	sigOut, err := io.Out.Single("sig")
+	sigOut, err := singleOut(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/union.go
+++ b/internal/runtime/funcs/union.go
@@ -10,19 +10,19 @@ type unionWrapper struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (unionWrapper) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	dataIn, err := io.In.Single("data")
+	dataIn, err := singleIn(io, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	tagIn, err := io.In.Single("tag")
+	tagIn, err := singleIn(io, "tag")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := io.Out.Single("res")
+	resOut, err := singleOut(io, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/wait_group.go
+++ b/internal/runtime/funcs/wait_group.go
@@ -10,19 +10,19 @@ type waitGroup struct{}
 
 //nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (g waitGroup) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	countIn, err := io.In.Single("count")
+	countIn, err := singleIn(io, "count")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	sigIn, err := io.In.Single("sig")
+	sigIn, err := singleIn(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	sigOut, err := io.Out.Single("sig")
+	sigOut, err := singleOut(io, "sig")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err

--- a/internal/runtime/funcs/write_all.go
+++ b/internal/runtime/funcs/write_all.go
@@ -11,25 +11,25 @@ type writeAll struct{}
 
 //nolint:gocognit // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (c writeAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Context), error) {
-	filenameIn, err := rio.In.Single("filename")
+	filenameIn, err := singleIn(rio, "filename")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	dataIn, err := rio.In.Single("data")
+	dataIn, err := singleIn(rio, "data")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	resOut, err := rio.Out.Single("res")
+	resOut, err := singleOut(rio, "res")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err
 	}
 
-	errOut, err := rio.Out.Single("err")
+	errOut, err := singleOut(rio, "err")
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 		return nil, err


### PR DESCRIPTION
## Summary
- add shared helper functions in `internal/runtime/funcs/ports.go`:
  - `singleIn`, `arrayIn`, `singleOut`, `arrayOut`
- migrate runtime func creators to use these helpers for IO port access
- standardize port lookup error context without changing runtime behavior

## Scope
- 102 files in `internal/runtime/funcs`
- mostly mechanical replacements plus one new helper file

## Validation
- `go test ./internal/runtime/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./internal/runtime/funcs/...`

## Guardrails
- `.golangci.yml` unchanged
- existing `//nolint:... // TODO(strict-lint phase 1)` comments preserved (count unchanged)
