### PR TITLE
refactor: add contextual errors in tooling paths

### DIFF
--- a/internal/builder/git.go
+++ b/internal/builder/git.go
@@ -46,7 +46,7 @@ func (p Builder) downloadDep(depModRef core.ModuleRef) (string, string, error) {
 	})
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return "", "", err
+		return "", "", fmt.Errorf("clone dependency %q: %w", depModRef.Path, err)
 	}
 
 	if ref != "" {
@@ -55,12 +55,12 @@ func (p Builder) downloadDep(depModRef core.ModuleRef) (string, string, error) {
 
 	latestTagHash, tagName, err := getLatestTagHash(repo)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("resolve latest tag for %q: %w", depModRef.Path, err)
 	}
 
 	if err := nevaGit.Checkout(repo, latestTagHash.String()); err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return "", "", err
+		return "", "", fmt.Errorf("checkout tag %q for %q: %w", tagName, depModRef.Path, err)
 	}
 
 	// Append the latest tag to the directory name
@@ -85,7 +85,7 @@ func getLatestTagHash(repository *gitlib.Repository) (plumbing.Hash, string, err
 	tagRefs, err := repository.Tags()
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return plumbing.Hash{}, "", err
+		return plumbing.Hash{}, "", fmt.Errorf("list repository tags: %w", err)
 	}
 
 	var (
@@ -99,7 +99,7 @@ func getLatestTagHash(repository *gitlib.Repository) (plumbing.Hash, string, err
 	})
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return plumbing.Hash{}, "", err
+		return plumbing.Hash{}, "", fmt.Errorf("iterate repository tags: %w", err)
 	}
 
 	return hash, strings.Split(name, "/")[2], nil

--- a/internal/builder/mod.go
+++ b/internal/builder/mod.go
@@ -53,7 +53,7 @@ func retrieveSourceCode(rootPath string, pkgs map[string]compiler.RawPackage) er
 		file, err := fsys.Open(filePath)
 		if err != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return err
+			return fmt.Errorf("open source file %q: %w", filePath, err)
 		}
 		defer file.Close()
 
@@ -61,7 +61,7 @@ func retrieveSourceCode(rootPath string, pkgs map[string]compiler.RawPackage) er
 		bb, err := io.ReadAll(file)
 		if err != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return err
+			return fmt.Errorf("read source file %q: %w", filePath, err)
 		}
 
 		pkgName := getPkgName(rootPath, filePath)

--- a/internal/compiler/backend/golang/wasm/backend.go
+++ b/internal/compiler/backend/golang/wasm/backend.go
@@ -20,13 +20,17 @@ func (b Backend) EmitExecutable(dst string, prog *ir.Program, trace bool) error 
 	tmpGoProj := dst + "/tmp"
 	if err := b.golang.EmitExecutable(tmpGoProj, prog, trace); err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("emit temporary Go project: %w", err)
 	}
 	if err := buildWASM(tmpGoProj, dst); err != nil {
-		return err
+		return fmt.Errorf("build wasm binary: %w", err)
 	}
 	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	return os.RemoveAll(tmpGoProj)
+	if err := os.RemoveAll(tmpGoProj); err != nil {
+		return fmt.Errorf("remove temporary project %q: %w", tmpGoProj, err)
+	}
+
+	return nil
 }
 
 func (b Backend) EmitLibrary(dst string, exports []compiler.LibraryExport, trace bool) error {
@@ -38,7 +42,7 @@ func buildWASM(src, dst string) error {
 	outputPath := filepath.Join(dst, "output")
 	if err := os.Chdir(src); err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("change working directory to %q: %w", src, err)
 	}
 	// #nosec G204 -- command args are constructed internally from known values
 	//nolint:noctx // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
@@ -50,7 +54,11 @@ func buildWASM(src, dst string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execute go wasm build: %w", err)
+	}
+
+	return nil
 }
 
 func NewBackend(golangBackend backendgolang.Backend) Backend {

--- a/pkg/golang/mod.go
+++ b/pkg/golang/mod.go
@@ -13,7 +13,7 @@ func FindModulePath(dst string) (string, error) {
 	absDst, err := filepath.Abs(dst)
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return "", err
+		return "", fmt.Errorf("resolve absolute path for %q: %w", dst, err)
 	}
 
 	dir := absDst
@@ -26,7 +26,7 @@ func FindModulePath(dst string) (string, error) {
 				f, err := os.Open(goModPath)
 				if err != nil {
 					//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-					return "", err
+					return "", fmt.Errorf("open go.mod %q: %w", goModPath, err)
 				}
 				defer f.Close()
 
@@ -38,7 +38,7 @@ func FindModulePath(dst string) (string, error) {
 						relPath, err := filepath.Rel(dir, absDst)
 						if err != nil {
 							//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-							return "", err
+							return "", fmt.Errorf("resolve module-relative path from %q to %q: %w", dir, absDst, err)
 						}
 						if relPath == "." {
 							return modName, nil
@@ -49,7 +49,7 @@ func FindModulePath(dst string) (string, error) {
 				return "", fmt.Errorf("module name not found in %s", goModPath)
 			}()
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("read module path from %q: %w", goModPath, err)
 			}
 			return modulePath, nil
 		}

--- a/pkg/os/copy.go
+++ b/pkg/os/copy.go
@@ -1,6 +1,7 @@
 package os
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	stdos "os"
@@ -13,30 +14,34 @@ import (
 func CopyFile(src, dst string, mode fs.FileMode) error {
 	if err := stdos.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("mkdir for %q: %w", dst, err)
 	}
 
 	srcFile, err := stdos.Open(src)
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("open source %q: %w", src, err)
 	}
 	defer srcFile.Close()
 
 	dstFile, err := stdos.OpenFile(dst, stdos.O_CREATE|stdos.O_WRONLY|stdos.O_TRUNC, mode.Perm())
 	if err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("open destination %q: %w", dst, err)
 	}
 	defer func() { _ = dstFile.Close() }()
 
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
 		//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-		return err
+		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
 	}
 
 	//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-	return dstFile.Close()
+	if err := dstFile.Close(); err != nil {
+		return fmt.Errorf("close destination %q: %w", dst, err)
+	}
+
+	return nil
 }
 
 // CopyDir recursively copies a directory tree preserving file modes.
@@ -44,13 +49,13 @@ func CopyDir(src, dst string) error {
 	//nolint:varnamelen,wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walk %q: %w", path, err)
 		}
 
 		rel, relErr := filepath.Rel(src, path)
 		if relErr != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return relErr
+			return fmt.Errorf("resolve relative path for %q: %w", path, relErr)
 		}
 
 		target := filepath.Join(dst, rel)
@@ -61,7 +66,7 @@ func CopyDir(src, dst string) error {
 		info, statErr := d.Info()
 		if statErr != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return statErr
+			return fmt.Errorf("stat %q: %w", path, statErr)
 		}
 
 		return CopyFile(path, target, info.Mode())

--- a/pkg/os/write.go
+++ b/pkg/os/write.go
@@ -1,6 +1,7 @@
 package os
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -12,13 +13,13 @@ func SaveFilesToDir(dst string, files map[string][]byte) error {
 
 		if err := os.MkdirAll(dirPath, 0o755); err != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return err
+			return fmt.Errorf("mkdir %q: %w", dirPath, err)
 		}
 
 		// #nosec G306 -- build outputs are intended to be readable
 		if err := os.WriteFile(filePath, content, 0o644); err != nil {
 			//nolint:wrapcheck // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			return err
+			return fmt.Errorf("write file %q: %w", filePath, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add contextual error wrapping in filesystem/repository operations used by tooling paths
- touched packages:
  - `pkg/os` (`copy.go`, `write.go`)
  - `pkg/golang` (`mod.go`)
  - `internal/builder` (`git.go`, `mod.go`)
  - `internal/compiler/backend/golang/wasm` (`backend.go`)
- preserve behavior while making failures easier to debug in CI/local runs

## Validation
- `go test ./pkg/os ./pkg/golang ./internal/builder ./internal/compiler/backend/golang/wasm`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./pkg/os/... ./pkg/golang/... ./internal/builder/... ./internal/compiler/backend/golang/wasm/...`

## Guardrails
- `.golangci.yml` unchanged
- existing `//nolint:... // TODO(strict-lint phase 1)` comments preserved (count unchanged)
