### PR TITLE
runtime/funcs: receive multi-input ports concurrently

### DIFF
--- a/internal/runtime/funcs/concurrent_inputs_test.go
+++ b/internal/runtime/funcs/concurrent_inputs_test.go
@@ -99,8 +99,8 @@ func assertOutputEquals(
 
 	select {
 	case got := <-outChans[outName]:
-		if !got.Msg.Equal(want) {
-			t.Fatalf("result = %v, want %v", got.Msg, want)
+		if !got.Equal(want) {
+			t.Fatalf("result = %v, want %v", got, want)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("no result for order %v", order)

--- a/internal/runtime/funcs/concurrent_inputs_test.go
+++ b/internal/runtime/funcs/concurrent_inputs_test.go
@@ -1,0 +1,133 @@
+package funcs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nevalang/neva/internal/runtime"
+)
+
+func TestFormatIntReceivesInputsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	io, inChans, outChans := newNamedRuntimeIO([]string{"data", "base"}, []string{"res"})
+	handler, err := (formatInt{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		handler(ctx)
+		close(done)
+	}()
+
+	for _, order := range [][]string{{"data", "base"}, {"base", "data"}} {
+		sendDone := make(chan struct{})
+		go func(order []string) {
+			for _, name := range order {
+				switch name {
+				case "data":
+					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(42)}
+				case "base":
+					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(10)}
+				}
+			}
+			close(sendDone)
+		}(order)
+
+		select {
+		case <-sendDone:
+		case <-time.After(time.Second):
+			t.Fatalf("sending blocked for order %v", order)
+		}
+
+		select {
+		case got := <-outChans["res"]:
+			if !got.Msg.Equal(runtime.NewStringMsg("42")) {
+				t.Fatalf("result = %v, want 42", got.Msg)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("no result for order %v", order)
+		}
+	}
+
+	cancel()
+	<-done
+}
+
+func TestTernaryReceivesInputsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	io, inChans, outChans := newNamedRuntimeIO([]string{"if", "then", "else"}, []string{"res"})
+	handler, err := (ternarySelector{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		handler(ctx)
+		close(done)
+	}()
+
+	for _, order := range [][]string{{"if", "then", "else"}, {"else", "then", "if"}} {
+		sendDone := make(chan struct{})
+		go func(order []string) {
+			for _, name := range order {
+				switch name {
+				case "if":
+					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewBoolMsg(true)}
+				case "then":
+					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewStringMsg("then")}
+				case "else":
+					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewStringMsg("else")}
+				}
+			}
+			close(sendDone)
+		}(order)
+
+		select {
+		case <-sendDone:
+		case <-time.After(time.Second):
+			t.Fatalf("sending blocked for order %v", order)
+		}
+
+		select {
+		case got := <-outChans["res"]:
+			if !got.Msg.Equal(runtime.NewStringMsg("then")) {
+				t.Fatalf("result = %v, want then", got.Msg)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("no result for order %v", order)
+		}
+	}
+
+	cancel()
+	<-done
+}
+
+func newNamedRuntimeIO(inNames []string, outNames []string) (runtime.IO, map[string]chan runtime.OrderedMsg, map[string]chan runtime.OrderedMsg) {
+	interceptor := runtime.ProdInterceptor{}
+	inports := make(map[string]runtime.Inport, len(inNames))
+	outports := make(map[string]runtime.Outport, len(outNames))
+	inChans := make(map[string]chan runtime.OrderedMsg, len(inNames))
+	outChans := make(map[string]chan runtime.OrderedMsg, len(outNames))
+
+	for _, name := range inNames {
+		ch := make(chan runtime.OrderedMsg)
+		inChans[name] = ch
+		inports[name] = runtime.NewInport(nil, runtime.NewSingleInport(ch, runtime.PortAddr{Path: "test/in", Port: name}, interceptor))
+	}
+
+	for _, name := range outNames {
+		ch := make(chan runtime.OrderedMsg, 1)
+		outChans[name] = ch
+		outports[name] = runtime.NewOutport(runtime.NewSingleOutport(runtime.PortAddr{Path: "test/out", Port: name}, interceptor, ch), nil)
+	}
+
+	return runtime.IO{In: runtime.NewInports(inports), Out: runtime.NewOutports(outports)}, inChans, outChans
+}

--- a/internal/runtime/funcs/concurrent_inputs_test.go
+++ b/internal/runtime/funcs/concurrent_inputs_test.go
@@ -25,33 +25,11 @@ func TestFormatIntReceivesInputsConcurrently(t *testing.T) {
 	}()
 
 	for _, order := range [][]string{{"data", "base"}, {"base", "data"}} {
-		sendDone := make(chan struct{})
-		go func(order []string) {
-			for _, name := range order {
-				switch name {
-				case "data":
-					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(42)}
-				case "base":
-					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(10)}
-				}
-			}
-			close(sendDone)
-		}(order)
-
-		select {
-		case <-sendDone:
-		case <-time.After(time.Second):
-			t.Fatalf("sending blocked for order %v", order)
-		}
-
-		select {
-		case got := <-outChans["res"]:
-			if !got.Msg.Equal(runtime.NewStringMsg("42")) {
-				t.Fatalf("result = %v, want 42", got.Msg)
-			}
-		case <-time.After(time.Second):
-			t.Fatalf("no result for order %v", order)
-		}
+		sendInOrder(t, inChans, order, map[string]runtime.Msg{
+			"data": runtime.NewIntMsg(42),
+			"base": runtime.NewIntMsg(10),
+		})
+		assertOutputEquals(t, outChans, "res", runtime.NewStringMsg("42"), order)
 	}
 
 	cancel()
@@ -75,39 +53,58 @@ func TestTernaryReceivesInputsConcurrently(t *testing.T) {
 	}()
 
 	for _, order := range [][]string{{"if", "then", "else"}, {"else", "then", "if"}} {
-		sendDone := make(chan struct{})
-		go func(order []string) {
-			for _, name := range order {
-				switch name {
-				case "if":
-					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewBoolMsg(true)}
-				case "then":
-					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewStringMsg("then")}
-				case "else":
-					inChans[name] <- runtime.OrderedMsg{Msg: runtime.NewStringMsg("else")}
-				}
-			}
-			close(sendDone)
-		}(order)
-
-		select {
-		case <-sendDone:
-		case <-time.After(time.Second):
-			t.Fatalf("sending blocked for order %v", order)
-		}
-
-		select {
-		case got := <-outChans["res"]:
-			if !got.Msg.Equal(runtime.NewStringMsg("then")) {
-				t.Fatalf("result = %v, want then", got.Msg)
-			}
-		case <-time.After(time.Second):
-			t.Fatalf("no result for order %v", order)
-		}
+		sendInOrder(t, inChans, order, map[string]runtime.Msg{
+			"if":   runtime.NewBoolMsg(true),
+			"then": runtime.NewStringMsg("then"),
+			"else": runtime.NewStringMsg("else"),
+		})
+		assertOutputEquals(t, outChans, "res", runtime.NewStringMsg("then"), order)
 	}
 
 	cancel()
 	<-done
+}
+
+func sendInOrder(
+	t *testing.T,
+	inChans map[string]chan runtime.OrderedMsg,
+	order []string,
+	payload map[string]runtime.Msg,
+) {
+	t.Helper()
+
+	sendDone := make(chan struct{})
+	go func() {
+		for _, name := range order {
+			inChans[name] <- runtime.OrderedMsg{Msg: payload[name]}
+		}
+		close(sendDone)
+	}()
+
+	select {
+	case <-sendDone:
+	case <-time.After(time.Second):
+		t.Fatalf("sending blocked for order %v", order)
+	}
+}
+
+func assertOutputEquals(
+	t *testing.T,
+	outChans map[string]chan runtime.OrderedMsg,
+	outName string,
+	want runtime.Msg,
+	order []string,
+) {
+	t.Helper()
+
+	select {
+	case got := <-outChans[outName]:
+		if !got.Msg.Equal(want) {
+			t.Fatalf("result = %v, want %v", got.Msg, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no result for order %v", order)
+	}
 }
 
 func newNamedRuntimeIO(inNames []string, outNames []string) (runtime.IO, map[string]chan runtime.OrderedMsg, map[string]chan runtime.OrderedMsg) {

--- a/internal/runtime/funcs/format_float.go
+++ b/internal/runtime/funcs/format_float.go
@@ -47,23 +47,7 @@ func (formatFloat) Create(
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			data, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			fmtMsg, ok := fmtIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			prec, ok := precIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			bits, ok := bitsIn.Receive(ctx)
+			data, fmtMsg, prec, bits, ok := receive4(ctx, dataIn, fmtIn, precIn, bitsIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/format_int.go
+++ b/internal/runtime/funcs/format_int.go
@@ -34,13 +34,7 @@ func (formatInt) Create(
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			data, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			base, ok := baseIn.Receive(ctx)
+			data, base, ok := receive2(ctx, dataIn, baseIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/list_at.go
+++ b/internal/runtime/funcs/list_at.go
@@ -36,13 +36,7 @@ func (listAt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), e
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			idxMsg, ok := idxIn.Receive(ctx)
+			dataMsg, idxMsg, ok := receive2(ctx, dataIn, idxIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/list_push.go
+++ b/internal/runtime/funcs/list_push.go
@@ -30,13 +30,7 @@ func (p listPush) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			lstMsg, ok := lstIn.Receive(ctx)
+			dataMsg, lstMsg, ok := receive2(ctx, dataIn, lstIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/parse_float.go
+++ b/internal/runtime/funcs/parse_float.go
@@ -39,13 +39,7 @@ func (p parseFloat) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Conte
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			bitsMsg, ok := bitsIn.Receive(ctx)
+			dataMsg, bitsMsg, ok := receive2(ctx, dataIn, bitsIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/parse_int.go
+++ b/internal/runtime/funcs/parse_int.go
@@ -45,18 +45,7 @@ func (p parseInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			baseMsg, ok := baseIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			bitsMsg, ok := bitsIn.Receive(ctx)
+			dataMsg, baseMsg, bitsMsg, ok := receive3(ctx, dataIn, baseIn, bitsIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/range_int.go
+++ b/internal/runtime/funcs/range_int.go
@@ -30,13 +30,7 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			fromMsg, ok := fromIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			toMsg, ok := toIn.Receive(ctx)
+			fromMsg, toMsg, ok := receive2(ctx, fromIn, toIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/regexp_submatch.go
+++ b/internal/runtime/funcs/regexp_submatch.go
@@ -38,8 +38,7 @@ func (r regexpSubmatch) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.C
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			regexpMsg, ok := regexpIn.Receive(ctx)
+			regexpMsg, dataMsg, ok := receive2(ctx, regexpIn, dataIn)
 			if !ok {
 				return
 			}
@@ -50,11 +49,6 @@ func (r regexpSubmatch) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.C
 					return
 				}
 				continue
-			}
-
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
 			}
 
 			if !resOut.Send(

--- a/internal/runtime/funcs/stream_zip.go
+++ b/internal/runtime/funcs/stream_zip.go
@@ -35,13 +35,7 @@ func (streamZip) Create(
 	return func(ctx context.Context) {
 		var idx int64
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			leftMsg, ok := leftIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			rightMsg, ok := rightIn.Receive(ctx)
+			leftMsg, rightMsg, ok := receive2(ctx, leftIn, rightIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/string_at.go
+++ b/internal/runtime/funcs/string_at.go
@@ -37,13 +37,7 @@ func (stringAt) Create(io runtime.IO, _ runtime.Msg) (func(context.Context), err
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			idxMsg, ok := idxIn.Receive(ctx)
+			dataMsg, idxMsg, ok := receive2(ctx, dataIn, idxIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/string_join.go
+++ b/internal/runtime/funcs/string_join.go
@@ -31,13 +31,7 @@ func (stringJoinList) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Con
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			sepMsg, ok := sepIn.Receive(ctx)
+			dataMsg, sepMsg, ok := receive2(ctx, dataIn, sepIn)
 			if !ok {
 				return
 			}
@@ -90,19 +84,33 @@ func (stringJoinStream) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.C
 		)
 
 		for {
-			msg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
 			if !hasSep {
-				sepMsg, ok := sepIn.Receive(ctx)
+				msg, sepMsg, ok := receive2(ctx, dataIn, sepIn)
 				if !ok {
 					return
 				}
 
 				sep = sepMsg.Str()
 				hasSep = true
+
+				item := msg.Struct()
+				if builder.Len() > 0 {
+					builder.WriteString(sep)
+				}
+				builder.WriteString(item.Get("data").Str())
+				if item.Get("last").Bool() {
+					if !resOut.Send(ctx, runtime.NewStringMsg(builder.String())) {
+						return
+					}
+					builder.Reset()
+					hasSep = false
+				}
+				continue
+			}
+
+			msg, ok := dataIn.Receive(ctx)
+			if !ok {
+				return
 			}
 
 			item := msg.Struct()

--- a/internal/runtime/funcs/string_join.go
+++ b/internal/runtime/funcs/string_join.go
@@ -84,53 +84,51 @@ func (stringJoinStream) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.C
 		)
 
 		for {
+			var msg runtime.Msg
+			var ok bool
+
 			if !hasSep {
-				msg, sepMsg, ok := receive2(ctx, dataIn, sepIn)
+				var sepMsg runtime.Msg
+				msg, sepMsg, ok = receive2(ctx, dataIn, sepIn)
 				if !ok {
 					return
 				}
 
 				sep = sepMsg.Str()
-				hasSep = true
-
-				item := msg.Struct()
-				if builder.Len() > 0 {
-					builder.WriteString(sep)
+			} else {
+				msg, ok = dataIn.Receive(ctx)
+				if !ok {
+					return
 				}
-				builder.WriteString(item.Get("data").Str())
-				if item.Get("last").Bool() {
-					if !resOut.Send(ctx, runtime.NewStringMsg(builder.String())) {
-						return
-					}
-					builder.Reset()
-					hasSep = false
-				}
-				continue
 			}
 
-			msg, ok := dataIn.Receive(ctx)
-			if !ok {
+			if !appendAndFlushJoinItem(ctx, resOut, &builder, sep, msg.Struct()) {
 				return
 			}
-
-			item := msg.Struct()
-
-			if builder.Len() > 0 {
-				builder.WriteString(sep)
-			}
-
-			builder.WriteString(item.Get("data").Str())
-
-			if !item.Get("last").Bool() {
-				continue
-			}
-
-			if !resOut.Send(ctx, runtime.NewStringMsg(builder.String())) {
-				return
-			}
-
-			builder.Reset()
-			hasSep = false
+			hasSep = builder.Len() > 0
 		}
 	}, nil
+}
+
+func appendAndFlushJoinItem(
+	ctx context.Context,
+	resOut runtime.SingleOutport,
+	builder *strings.Builder,
+	sep string,
+	item runtime.StructMsg,
+) bool {
+	if builder.Len() > 0 {
+		builder.WriteString(sep)
+	}
+	builder.WriteString(item.Get("data").Str())
+
+	if !item.Get("last").Bool() {
+		return true
+	}
+
+	if !resOut.Send(ctx, runtime.NewStringMsg(builder.String())) {
+		return false
+	}
+	builder.Reset()
+	return true
 }

--- a/internal/runtime/funcs/string_split.go
+++ b/internal/runtime/funcs/string_split.go
@@ -31,13 +31,7 @@ func (p stringsSplit) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Con
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			data, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			delim, ok := delimIn.Receive(ctx)
+			data, delim, ok := receive2(ctx, dataIn, delimIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/ternary.go
+++ b/internal/runtime/funcs/ternary.go
@@ -36,18 +36,7 @@ func (p ternarySelector) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := ifIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			thenMsg, ok := thenIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			elseMsg, ok := elseIn.Receive(ctx)
+			dataMsg, thenMsg, elseMsg, ok := receive3(ctx, ifIn, thenIn, elseIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/time_delay.go
+++ b/internal/runtime/funcs/time_delay.go
@@ -31,13 +31,7 @@ func (timeDelay) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context)
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			durMsg, ok := durIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			dataMsg, ok := dataIn.Receive(ctx)
+			durMsg, dataMsg, ok := receive2(ctx, durIn, dataIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/union.go
+++ b/internal/runtime/funcs/union.go
@@ -30,13 +30,7 @@ func (unionWrapper) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Conte
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			tagMsg, ok := tagIn.Receive(ctx)
+			dataMsg, tagMsg, ok := receive2(ctx, dataIn, tagIn)
 			if !ok {
 				return
 			}

--- a/internal/runtime/funcs/utils.go
+++ b/internal/runtime/funcs/utils.go
@@ -1,6 +1,11 @@
 package funcs
 
-import "github.com/nevalang/neva/internal/runtime"
+import (
+	"context"
+	"sync"
+
+	"github.com/nevalang/neva/internal/runtime"
+)
 
 func errFromErr(err error) runtime.StructMsg {
 	return errFromString(err.Error())
@@ -23,4 +28,76 @@ func streamItem(data runtime.Msg, idx int64, last bool) runtime.StructMsg {
 
 func emptyStruct() runtime.StructMsg {
 	return runtime.NewStructMsg(nil)
+}
+
+func receive2(
+	ctx context.Context,
+	firstIn runtime.SingleInport,
+	secondIn runtime.SingleInport,
+) (runtime.Msg, runtime.Msg, bool) {
+	var firstMsg, secondMsg runtime.Msg
+	var firstOK, secondOK bool
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		firstMsg, firstOK = firstIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		secondMsg, secondOK = secondIn.Receive(ctx)
+	})
+	wg.Wait()
+
+	return firstMsg, secondMsg, firstOK && secondOK
+}
+
+func receive3(
+	ctx context.Context,
+	firstIn runtime.SingleInport,
+	secondIn runtime.SingleInport,
+	thirdIn runtime.SingleInport,
+) (runtime.Msg, runtime.Msg, runtime.Msg, bool) {
+	var firstMsg, secondMsg, thirdMsg runtime.Msg
+	var firstOK, secondOK, thirdOK bool
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		firstMsg, firstOK = firstIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		secondMsg, secondOK = secondIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		thirdMsg, thirdOK = thirdIn.Receive(ctx)
+	})
+	wg.Wait()
+
+	return firstMsg, secondMsg, thirdMsg, firstOK && secondOK && thirdOK
+}
+
+func receive4(
+	ctx context.Context,
+	firstIn runtime.SingleInport,
+	secondIn runtime.SingleInport,
+	thirdIn runtime.SingleInport,
+	fourthIn runtime.SingleInport,
+) (runtime.Msg, runtime.Msg, runtime.Msg, runtime.Msg, bool) {
+	var firstMsg, secondMsg, thirdMsg, fourthMsg runtime.Msg
+	var firstOK, secondOK, thirdOK, fourthOK bool
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		firstMsg, firstOK = firstIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		secondMsg, secondOK = secondIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		thirdMsg, thirdOK = thirdIn.Receive(ctx)
+	})
+	wg.Go(func() {
+		fourthMsg, fourthOK = fourthIn.Receive(ctx)
+	})
+	wg.Wait()
+
+	return firstMsg, secondMsg, thirdMsg, fourthMsg, firstOK && secondOK && thirdOK && fourthOK
 }

--- a/internal/runtime/funcs/utils.go
+++ b/internal/runtime/funcs/utils.go
@@ -30,6 +30,7 @@ func emptyStruct() runtime.StructMsg {
 	return runtime.NewStructMsg(nil)
 }
 
+//nolint:ireturn // runtime.Msg is the runtime contract type for function ports.
 func receive2(
 	ctx context.Context,
 	firstIn runtime.SingleInport,
@@ -38,18 +39,19 @@ func receive2(
 	var firstMsg, secondMsg runtime.Msg
 	var firstOK, secondOK bool
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
+	var waitGroup sync.WaitGroup
+	waitGroup.Go(func() {
 		firstMsg, firstOK = firstIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		secondMsg, secondOK = secondIn.Receive(ctx)
 	})
-	wg.Wait()
+	waitGroup.Wait()
 
 	return firstMsg, secondMsg, firstOK && secondOK
 }
 
+//nolint:ireturn // runtime.Msg is the runtime contract type for function ports.
 func receive3(
 	ctx context.Context,
 	firstIn runtime.SingleInport,
@@ -59,21 +61,22 @@ func receive3(
 	var firstMsg, secondMsg, thirdMsg runtime.Msg
 	var firstOK, secondOK, thirdOK bool
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
+	var waitGroup sync.WaitGroup
+	waitGroup.Go(func() {
 		firstMsg, firstOK = firstIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		secondMsg, secondOK = secondIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		thirdMsg, thirdOK = thirdIn.Receive(ctx)
 	})
-	wg.Wait()
+	waitGroup.Wait()
 
 	return firstMsg, secondMsg, thirdMsg, firstOK && secondOK && thirdOK
 }
 
+//nolint:ireturn // runtime.Msg is the runtime contract type for function ports.
 func receive4(
 	ctx context.Context,
 	firstIn runtime.SingleInport,
@@ -84,20 +87,20 @@ func receive4(
 	var firstMsg, secondMsg, thirdMsg, fourthMsg runtime.Msg
 	var firstOK, secondOK, thirdOK, fourthOK bool
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
+	var waitGroup sync.WaitGroup
+	waitGroup.Go(func() {
 		firstMsg, firstOK = firstIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		secondMsg, secondOK = secondIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		thirdMsg, thirdOK = thirdIn.Receive(ctx)
 	})
-	wg.Go(func() {
+	waitGroup.Go(func() {
 		fourthMsg, fourthOK = fourthIn.Receive(ctx)
 	})
-	wg.Wait()
+	waitGroup.Wait()
 
 	return firstMsg, secondMsg, thirdMsg, fourthMsg, firstOK && secondOK && thirdOK && fourthOK
 }

--- a/internal/runtime/funcs/write_all.go
+++ b/internal/runtime/funcs/write_all.go
@@ -37,13 +37,7 @@ func (c writeAll) Create(rio runtime.IO, _ runtime.Msg) (func(ctx context.Contex
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			filenameMsg, ok := filenameIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
-			dataMsg, ok := dataIn.Receive(ctx)
+			filenameMsg, dataMsg, ok := receive2(ctx, filenameIn, dataIn)
 			if !ok {
 				return
 			}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
       stage_fixed: true
     golangci-fix:
       glob: "*.go"
-      run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run --fix {staged_files}
+      run: scripts/hooks/precommit-golangci-fix.sh
       stage_fixed: true
 
 pre-push:

--- a/scripts/hooks/precommit-golangci-fix.sh
+++ b/scripts/hooks/precommit-golangci-fix.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+files=$(git diff --cached --name-only -- '*.go')
+if [ -z "$files" ]; then
+  echo "no staged Go files"
+  exit 0
+fi
+
+targets=$(printf '%s\n' "$files" | while IFS= read -r file; do
+  dir=$(dirname "$file")
+  if [ "$dir" = "." ]; then
+    echo "./..."
+  else
+    echo "./$dir/..."
+  fi
+done | sort -u)
+
+# shellcheck disable=SC2086
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run --fix $targets


### PR DESCRIPTION
## Summary
- audit multi-input runtime funcs that were receiving inports sequentially
- switch safe cases to concurrent receive helpers to avoid opposite-order send deadlocks
- add focused regression tests for opposite-order sends on unbuffered channels

Closes #1113