### PR TITLE
docs: add vision and Neva comment conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ flowchart LR
 
 </div>
 
+## Vision
+
+See **[docs/vision.md](./docs/vision.md)** for Neva principles: hybrid programming, concurrency-first design, static reliability, and AI-native ergonomics.
+
 ## Why?
 
 1. Controlflow paradigm is is well established while dataflow is underrepresented.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ flowchart LR
 
 </div>
 
-## Vision
-
-See **[docs/vision.md](./docs/vision.md)** for Neva principles: hybrid programming, concurrency-first design, static reliability, and AI-native ergonomics.
-
 ## Why?
 
 1. Controlflow paradigm is is well established while dataflow is underrepresented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,10 @@
 
 Welcome to Nevalang documentation!
 
-- **[History](./history.md)** - How it all started.
-- **[Comparison](./comparison.md)** - How Nevalang compares to other languages.
+- **[Vision](./vision.md)** - Language principles and product direction.
 - **[Tutorial](./tutorial.md)** - Best place to start.
-- **[Style Guide](./style_guide.md)** - Best practices to follow.
 - **[Questions and Answers](./qna.md)** - If you curious why things exactly the way they are.
+- **[Style Guide](./style_guide.md)** - Best practices to follow.
+- **[Comparison](./comparison.md)** - How Nevalang compares to other languages.
+- **[History](./history.md)** - How it all started.
 - **[The Book](./book/README.md)** - A deep dive into the language and how it works. Make sure you've read tutorial!

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -61,3 +61,34 @@ Names should inherit context from parent scope. Good naming eliminates need for 
 - Omit port names when possible. It enables renaming of ports without updating the networks.
 - Use `?` to propagate errors unless custom error handling is needed.
 - Prefer chaining connections inline when possible (e.g. `c -> switch:case[0] -> fmt.Println`) to keep the dataflow compact and easier to scan.
+
+## Comments
+
+Good comments explain why.
+
+Use leading `//` block immediately above entity.
+
+- Free text is allowed and should describe intent/constraints.
+- Use `@inport <name> <text>` for inport semantics.
+- Use `@outport <name> <text>` for outport semantics.
+- Use `@example <text>` for external usage examples (how to use component from outside).
+- Multiple `@example` lines are allowed.
+- Separate logical sections with an empty commented line (`//`).
+
+Example:
+
+```neva
+// Processes payload and returns normalized result.
+// Keeps stable behavior for repeated start signals.
+//
+// @inport start Trigger signal.
+// @inport data Input payload.
+//
+// @outport res Normalized payload.
+// @outport err Processing error.
+//
+// @example :start -> process:start
+// @example 'hello' -> process:data
+// @example process:res -> :stop
+def Process(start any, data string) (res string, err error)
+```

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,62 @@
+# Vision
+
+Neva is a general-purpose, statically typed, compiled dataflow language.
+
+Its core value is not a single feature, but a combination of properties that
+work together:
+
+1. Hybrid programming model (text + visual tooling).
+2. Concurrency-first execution model.
+3. Strong static semantics and reliability.
+4. AI-native development ergonomics.
+
+## Core Principles
+
+### 1) Hybrid Programming (Text + Visual)
+
+Neva source remains a first-class text language, but the language model is also
+optimized for visual programming workflows.
+
+This is not "visual-only" positioning. It is a unified language that supports
+both manual coding and visual graph workflows without semantic mismatch.
+
+### 2) Concurrency-First By Design
+
+Neva is designed around explicit node/edge dataflow, where concurrent execution
+is default behavior rather than an advanced add-on.
+
+Goal: make scalable multi-core utilization natural at language level, while
+preserving predictable reasoning about program behavior.
+
+### 3) Reliability Through Static Semantics
+
+Neva prioritizes compile-time guarantees:
+
+- strict static typing;
+- semantic analysis before runtime;
+- explicit data movement contracts;
+- minimized surface for unsafe/implicit behavior.
+
+The language should be easy to analyze and hard to misuse accidentally.
+
+### 4) AI-Native, Without Sacrificing Human Authoring
+
+Neva should be ergonomic for both:
+
+1. human-written code (readable, maintainable, explicit);
+2. AI-generated code (predictable, structurally consistent, easy to validate).
+
+AI-native direction must not degrade manual development quality.
+
+## Product/Application Tracks
+
+Neva targets multiple practical domains where dataflow and concurrency are
+valuable:
+
+1. Web development (frontend/backend/fullstack workflows).
+2. Streaming and event-driven processing.
+3. Data transformation pipelines, including ETL-style workloads.
+4. Network/distributed and integration-heavy systems.
+5. ML-adjacent workloads where static contracts and pipelines matter.
+
+These tracks are complementary. No single track defines Neva alone.

--- a/internal/compiler/parser/AGENTS.md
+++ b/internal/compiler/parser/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md (parser)
+
+Scoped guidance for `internal/compiler/parser`.
+
+## Parser Contract
+
+1. Parser output must be structurally parsed AST data.
+2. After parser stage, there should be no remaining syntax-level mini-languages
+   that still require parsing to recover intended structure.
+3. If current implementation violates this rule for compatibility or incremental
+   delivery reasons, document the exception near the code and keep it temporary.
+4. Prefer explicit AST fields over deferred string parsing in later compiler stages.

--- a/internal/compiler/parser/comments_helpers.go
+++ b/internal/compiler/parser/comments_helpers.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/nevalang/neva/internal/compiler"
@@ -9,9 +8,10 @@ import (
 	"github.com/nevalang/neva/pkg/core"
 )
 
+//nolint:gocyclo,cyclop // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 func (s *treeShapeListener) parseLeadingComments(
 	entityLine int,
-	io src.IO,
+	ports *src.IO,
 ) (*src.Comments, *compiler.Error) {
 	lines, startLine, stopLine := s.leadingCommentLines(entityLine)
 	if len(lines) == 0 {
@@ -50,33 +50,8 @@ func (s *treeShapeListener) parseLeadingComments(
 		textBuf = textBuf[:0]
 
 		tagName, tagValue := splitTag(trimmed[1:])
-		switch tagName {
-		case "inport":
-			portName, desc := splitFirstWord(tagValue)
-			if portName == "" {
-				return nil, s.commentParseError("invalid @inport tag: port name is required", startLine)
-			}
-			if _, ok := io.In[portName]; !ok {
-				return nil, s.commentParseError(fmt.Sprintf("unknown @inport reference: %s", portName), startLine)
-			}
-			comments.Inports[portName] = desc
-		case "outport":
-			portName, desc := splitFirstWord(tagValue)
-			if portName == "" {
-				return nil, s.commentParseError("invalid @outport tag: port name is required", startLine)
-			}
-			if _, ok := io.Out[portName]; !ok {
-				return nil, s.commentParseError(fmt.Sprintf("unknown @outport reference: %s", portName), startLine)
-			}
-			comments.Outports[portName] = desc
-		case "example":
-			comments.Examples = append(comments.Examples, tagValue)
-		default:
-			// Parser intentionally keeps unknown tags for CLI/AI and third-party tooling.
-			comments.Tags = append(comments.Tags, src.CommentTag{
-				Name:  tagName,
-				Value: tagValue,
-			})
+		if err := s.consumeTag(comments, ports, startLine, tagName, tagValue); err != nil {
+			return nil, err
 		}
 	}
 	s.flushTextBlock(comments, textBuf)
@@ -95,6 +70,45 @@ func (s *treeShapeListener) parseLeadingComments(
 	return comments, nil
 }
 
+func (s *treeShapeListener) consumeTag(
+	comments *src.Comments,
+	ports *src.IO,
+	startLine int,
+	tagName string,
+	tagValue string,
+) *compiler.Error {
+	switch tagName {
+	case "inport":
+		portName, desc := splitFirstWord(tagValue)
+		if portName == "" {
+			return s.commentParseError("invalid @inport tag: port name is required", startLine)
+		}
+		if _, ok := ports.In[portName]; !ok {
+			return s.commentParseError("unknown @inport reference: "+portName, startLine)
+		}
+		comments.Inports[portName] = desc
+	case "outport":
+		portName, desc := splitFirstWord(tagValue)
+		if portName == "" {
+			return s.commentParseError("invalid @outport tag: port name is required", startLine)
+		}
+		if _, ok := ports.Out[portName]; !ok {
+			return s.commentParseError("unknown @outport reference: "+portName, startLine)
+		}
+		comments.Outports[portName] = desc
+	case "example":
+		comments.Examples = append(comments.Examples, tagValue)
+	default:
+		// Parser intentionally keeps unknown tags for CLI/AI and third-party tooling.
+		comments.Tags = append(comments.Tags, src.CommentTag{
+			Name:  tagName,
+			Value: tagValue,
+		})
+	}
+
+	return nil
+}
+
 func (s *treeShapeListener) flushTextBlock(comments *src.Comments, textLines []string) {
 	if len(textLines) == 0 {
 		return
@@ -107,24 +121,24 @@ func (s *treeShapeListener) leadingCommentLines(entityLine int) ([]string, int, 
 		return nil, 0, 0
 	}
 
-	i := entityLine - 2 // 0-based line before entity declaration.
-	line := strings.TrimSpace(s.sourceLines[i])
+	lineIdx := entityLine - 2 // 0-based line before entity declaration.
+	line := strings.TrimSpace(s.sourceLines[lineIdx])
 	if !strings.HasPrefix(line, "//") {
 		return nil, 0, 0
 	}
 
 	raw := make([]string, 0, 8)
-	start := i + 1
-	stop := i + 1
-	for ; i >= 0; i-- {
-		trimmed := strings.TrimSpace(s.sourceLines[i])
+	start := lineIdx + 1
+	stop := lineIdx + 1
+	for ; lineIdx >= 0; lineIdx-- {
+		trimmed := strings.TrimSpace(s.sourceLines[lineIdx])
 		if !strings.HasPrefix(trimmed, "//") {
 			break
 		}
 		content := strings.TrimPrefix(trimmed, "//")
 		content = strings.TrimPrefix(content, " ")
 		raw = append(raw, content)
-		start = i + 1
+		start = lineIdx + 1
 	}
 
 	// reverse to keep source order.
@@ -140,14 +154,14 @@ func splitTag(s string) (string, string) {
 	return strings.ToLower(name), value
 }
 
-func splitFirstWord(s string) (string, string) {
-	parts := strings.Fields(s)
+func splitFirstWord(text string) (string, string) {
+	parts := strings.Fields(text)
 	if len(parts) == 0 {
 		return "", ""
 	}
 	name := parts[0]
-	idx := strings.Index(s, name)
-	rest := strings.TrimSpace(s[idx+len(name):])
+	idx := strings.Index(text, name)
+	rest := strings.TrimSpace(text[idx+len(name):])
 	return name, rest
 }
 

--- a/internal/compiler/parser/comments_helpers.go
+++ b/internal/compiler/parser/comments_helpers.go
@@ -1,0 +1,169 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nevalang/neva/internal/compiler"
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
+)
+
+func (s *treeShapeListener) parseLeadingComments(
+	entityLine int,
+	io src.IO,
+) (*src.Comments, *compiler.Error) {
+	lines, startLine, stopLine := s.leadingCommentLines(entityLine)
+	if len(lines) == 0 {
+		return nil, nil
+	}
+
+	comments := &src.Comments{
+		Inports:  map[string]string{},
+		Outports: map[string]string{},
+		Meta: core.Meta{
+			Start: core.Position{Line: startLine, Column: 0},
+			Stop:  core.Position{Line: stopLine, Column: 0},
+			Location: core.Location{
+				ModRef:   s.loc.ModRef,
+				Package:  s.loc.Package,
+				Filename: s.loc.Filename,
+			},
+		},
+	}
+
+	textBuf := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			s.flushTextBlock(comments, textBuf)
+			textBuf = textBuf[:0]
+			continue
+		}
+
+		if !strings.HasPrefix(trimmed, "@") {
+			textBuf = append(textBuf, line)
+			continue
+		}
+
+		s.flushTextBlock(comments, textBuf)
+		textBuf = textBuf[:0]
+
+		tagName, tagValue := splitTag(trimmed[1:])
+		switch tagName {
+		case "inport":
+			portName, desc := splitFirstWord(tagValue)
+			if portName == "" {
+				return nil, s.commentParseError("invalid @inport tag: port name is required", startLine)
+			}
+			if _, ok := io.In[portName]; !ok {
+				return nil, s.commentParseError(fmt.Sprintf("unknown @inport reference: %s", portName), startLine)
+			}
+			comments.Inports[portName] = desc
+		case "outport":
+			portName, desc := splitFirstWord(tagValue)
+			if portName == "" {
+				return nil, s.commentParseError("invalid @outport tag: port name is required", startLine)
+			}
+			if _, ok := io.Out[portName]; !ok {
+				return nil, s.commentParseError(fmt.Sprintf("unknown @outport reference: %s", portName), startLine)
+			}
+			comments.Outports[portName] = desc
+		case "example":
+			comments.Examples = append(comments.Examples, tagValue)
+		default:
+			// Parser intentionally keeps unknown tags for CLI/AI and third-party tooling.
+			comments.Tags = append(comments.Tags, src.CommentTag{
+				Name:  tagName,
+				Value: tagValue,
+			})
+		}
+	}
+	s.flushTextBlock(comments, textBuf)
+
+	if len(comments.Inports) == 0 {
+		comments.Inports = nil
+	}
+	if len(comments.Outports) == 0 {
+		comments.Outports = nil
+	}
+	if len(comments.TextBlocks) == 0 && len(comments.Inports) == 0 &&
+		len(comments.Outports) == 0 && len(comments.Examples) == 0 && len(comments.Tags) == 0 {
+		return nil, nil
+	}
+
+	return comments, nil
+}
+
+func (s *treeShapeListener) flushTextBlock(comments *src.Comments, textLines []string) {
+	if len(textLines) == 0 {
+		return
+	}
+	comments.TextBlocks = append(comments.TextBlocks, strings.Join(textLines, "\n"))
+}
+
+func (s *treeShapeListener) leadingCommentLines(entityLine int) ([]string, int, int) {
+	if entityLine <= 1 || entityLine-2 >= len(s.sourceLines) {
+		return nil, 0, 0
+	}
+
+	i := entityLine - 2 // 0-based line before entity declaration.
+	line := strings.TrimSpace(s.sourceLines[i])
+	if !strings.HasPrefix(line, "//") {
+		return nil, 0, 0
+	}
+
+	raw := make([]string, 0, 8)
+	start := i + 1
+	stop := i + 1
+	for ; i >= 0; i-- {
+		trimmed := strings.TrimSpace(s.sourceLines[i])
+		if !strings.HasPrefix(trimmed, "//") {
+			break
+		}
+		content := strings.TrimPrefix(trimmed, "//")
+		content = strings.TrimPrefix(content, " ")
+		raw = append(raw, content)
+		start = i + 1
+	}
+
+	// reverse to keep source order.
+	for left, right := 0, len(raw)-1; left < right; left, right = left+1, right-1 {
+		raw[left], raw[right] = raw[right], raw[left]
+	}
+
+	return raw, start, stop
+}
+
+func splitTag(s string) (string, string) {
+	name, value := splitFirstWord(s)
+	return strings.ToLower(name), value
+}
+
+func splitFirstWord(s string) (string, string) {
+	parts := strings.Fields(s)
+	if len(parts) == 0 {
+		return "", ""
+	}
+	name := parts[0]
+	idx := strings.Index(s, name)
+	rest := strings.TrimSpace(s[idx+len(name):])
+	return name, rest
+}
+
+func (s *treeShapeListener) commentParseError(message string, line int) *compiler.Error {
+	return &compiler.Error{
+		Message: message,
+		Meta: &core.Meta{
+			Start: core.Position{
+				Line:   line,
+				Column: 0,
+			},
+			Location: core.Location{
+				ModRef:   s.loc.ModRef,
+				Package:  s.loc.Package,
+				Filename: s.loc.Filename,
+			},
+		},
+	}
+}

--- a/internal/compiler/parser/listener.go
+++ b/internal/compiler/parser/listener.go
@@ -9,7 +9,8 @@ import (
 type treeShapeListener struct {
 	state src.File
 	*generated.BasenevaListener
-	loc core.Location
+	loc         core.Location
+	sourceLines []string
 }
 
 func (s *treeShapeListener) EnterProg(actx *generated.ProgContext) {
@@ -34,6 +35,11 @@ func (s *treeShapeListener) EnterTypeStmt(actx *generated.TypeStmtContext) {
 	}
 
 	parsedEntity.IsPublic = actx.PUB() != nil
+	comments, err := s.parseLeadingComments(typeDef.GetStart().GetLine(), src.IO{})
+	if err != nil {
+		panic(err)
+	}
+	parsedEntity.Comments = comments
 	nameIdent := typeDef.IDENTIFIER()
 	if nameIdent == nil {
 		panic("missing type identifier")
@@ -54,6 +60,11 @@ func (s *treeShapeListener) EnterConstStmt(actx *generated.ConstStmtContext) {
 	}
 
 	parsedEntity.IsPublic = actx.PUB() != nil
+	comments, err := s.parseLeadingComments(constDef.GetStart().GetLine(), src.IO{})
+	if err != nil {
+		panic(err)
+	}
+	parsedEntity.Comments = comments
 	nameIdent := constDef.IDENTIFIER()
 	if nameIdent == nil {
 		panic("missing const identifier")
@@ -73,6 +84,11 @@ func (s *treeShapeListener) EnterInterfaceStmt(actx *generated.InterfaceStmtCont
 	if err != nil {
 		panic(err)
 	}
+	comments, err := s.parseLeadingComments(ifaceDef.GetStart().GetLine(), v.IO)
+	if err != nil {
+		panic(err)
+	}
+
 	nameIdent := ifaceDef.IDENTIFIER()
 	if nameIdent == nil {
 		panic("missing interface identifier")
@@ -82,6 +98,7 @@ func (s *treeShapeListener) EnterInterfaceStmt(actx *generated.InterfaceStmtCont
 		IsPublic:  actx.PUB() != nil,
 		Kind:      src.InterfaceEntity,
 		Interface: v,
+		Comments:  comments,
 	}
 }
 
@@ -109,6 +126,10 @@ func (s *treeShapeListener) EnterCompStmt(actx *generated.CompStmtContext) {
 	parsedComponent.Directives = s.parseCompilerDirectives(
 		actx.CompilerDirectives(),
 	)
+	comments, err := s.parseLeadingComments(compDef.GetStart().GetLine(), parsedComponent.IO)
+	if err != nil {
+		panic(err)
+	}
 
 	existing, ok := s.state.Entities[name]
 	if !ok {
@@ -116,11 +137,15 @@ func (s *treeShapeListener) EnterCompStmt(actx *generated.CompStmtContext) {
 			Kind:      src.ComponentEntity,
 			IsPublic:  actx.PUB() != nil, // in case of overloaded component, first version sets visibility
 			Component: []src.Component{parsedComponent},
+			Comments:  comments,
 		}
 		return
 	}
 
 	existing.Component = append(existing.Component, parsedComponent)
+	if comments != nil {
+		existing.Comments = comments
+	}
 
 	// store back the updated entity; without this, only the first overload is kept
 	s.state.Entities[name] = existing

--- a/internal/compiler/parser/listener.go
+++ b/internal/compiler/parser/listener.go
@@ -35,7 +35,7 @@ func (s *treeShapeListener) EnterTypeStmt(actx *generated.TypeStmtContext) {
 	}
 
 	parsedEntity.IsPublic = actx.PUB() != nil
-	comments, err := s.parseLeadingComments(typeDef.GetStart().GetLine(), src.IO{})
+	comments, err := s.parseLeadingComments(typeDef.GetStart().GetLine(), &src.IO{})
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +60,7 @@ func (s *treeShapeListener) EnterConstStmt(actx *generated.ConstStmtContext) {
 	}
 
 	parsedEntity.IsPublic = actx.PUB() != nil
-	comments, err := s.parseLeadingComments(constDef.GetStart().GetLine(), src.IO{})
+	comments, err := s.parseLeadingComments(constDef.GetStart().GetLine(), &src.IO{})
 	if err != nil {
 		panic(err)
 	}
@@ -84,7 +84,7 @@ func (s *treeShapeListener) EnterInterfaceStmt(actx *generated.InterfaceStmtCont
 	if err != nil {
 		panic(err)
 	}
-	comments, err := s.parseLeadingComments(ifaceDef.GetStart().GetLine(), v.IO)
+	comments, err := s.parseLeadingComments(ifaceDef.GetStart().GetLine(), &v.IO)
 	if err != nil {
 		panic(err)
 	}
@@ -126,7 +126,7 @@ func (s *treeShapeListener) EnterCompStmt(actx *generated.CompStmtContext) {
 	parsedComponent.Directives = s.parseCompilerDirectives(
 		actx.CompilerDirectives(),
 	)
-	comments, err := s.parseLeadingComments(compDef.GetStart().GetLine(), parsedComponent.IO)
+	comments, err := s.parseLeadingComments(compDef.GetStart().GetLine(), &parsedComponent.IO)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/compiler/parser/parser.go
+++ b/internal/compiler/parser/parser.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
 
@@ -107,6 +108,7 @@ func (p Parser) parseFile(
 			Package:  pkgName,
 			Filename: fileName,
 		},
+		sourceLines: strings.Split(string(content), "\n"),
 	}
 
 	if err := walkTree(listener, prsr.Prog()); err != nil {

--- a/internal/compiler/parser/parser_test.go
+++ b/internal/compiler/parser/parser_test.go
@@ -240,6 +240,65 @@ func TestParser_ParseFile_Comments(t *testing.T) {
 	require.True(t, err == nil)
 }
 
+func TestParser_ParseFile_EntityComments(t *testing.T) {
+	text := []byte(`
+		// Processes payload.
+		// Stable behavior.
+		//
+		// @inport start Trigger signal.
+		// @inport data Input payload.
+		//
+		// @outport res Processed result.
+		// @outport err Processing error.
+		//
+		// @example :start -> process:start
+		// @example 'hello' -> process:data
+		// @custom owned-by-ai-cli
+		def Process(start any, data string) (res string, err error)
+	`)
+
+	p := New()
+	got, err := p.parseFile(location.ModRef, location.Package, location.Filename, text)
+	require.Nil(t, err)
+
+	entity := got.Entities["Process"]
+	require.NotNil(t, entity.Comments)
+	require.Equal(t, []string{"Processes payload.\nStable behavior."}, entity.Comments.TextBlocks)
+	require.Equal(t, "Trigger signal.", entity.Comments.Inports["start"])
+	require.Equal(t, "Input payload.", entity.Comments.Inports["data"])
+	require.Equal(t, "Processed result.", entity.Comments.Outports["res"])
+	require.Equal(t, "Processing error.", entity.Comments.Outports["err"])
+	require.Equal(t, []string{":start -> process:start", "'hello' -> process:data"}, entity.Comments.Examples)
+	require.Len(t, entity.Comments.Tags, 1)
+	require.Equal(t, "custom", entity.Comments.Tags[0].Name)
+	require.Equal(t, "owned-by-ai-cli", entity.Comments.Tags[0].Value)
+}
+
+func TestParser_ParseFile_EntityCommentsBlankLineNotAttached(t *testing.T) {
+	text := []byte(`
+		// Not attached due to blank line.
+
+		def Process(start any) (stop any)
+	`)
+
+	p := New()
+	got, err := p.parseFile(location.ModRef, location.Package, location.Filename, text)
+	require.Nil(t, err)
+	require.Nil(t, got.Entities["Process"].Comments)
+}
+
+func TestParser_ParseFile_EntityCommentsUnknownPortFails(t *testing.T) {
+	text := []byte(`
+		// @inport missing does-not-exist
+		def Process(start any) (stop any)
+	`)
+
+	p := New()
+	_, err := p.parseFile(location.ModRef, location.Package, location.Filename, text)
+	require.NotNil(t, err)
+	require.Contains(t, err.Message, "unknown @inport reference")
+}
+
 func TestParser_ParseFile_Directives(t *testing.T) {
 	text := []byte(`
 		#extern(d1)

--- a/pkg/ast/comments.go
+++ b/pkg/ast/comments.go
@@ -1,0 +1,18 @@
+package ast
+
+import "github.com/nevalang/neva/pkg/core"
+
+// Comments is a parsed comment payload attached to an entity.
+type Comments struct {
+	TextBlocks []string          `json:"textBlocks,omitempty"`
+	Inports    map[string]string `json:"inports,omitempty"`
+	Outports   map[string]string `json:"outports,omitempty"`
+	Examples   []string          `json:"examples,omitempty"`
+	Tags       []CommentTag      `json:"tags,omitempty"`
+	Meta       core.Meta         `json:"meta"`
+}
+
+type CommentTag struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -64,10 +64,11 @@ func (p Package) Entity(entityName string) (entity Entity, filename string, ok b
 	return Entity{}, "", false
 }
 
+//nolint:govet // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 type EntitiesResult struct {
+	Entity     Entity
 	EntityName string
 	FileName   string
-	Entity     Entity
 }
 
 // Entities iterates over all entities in the package using the range-func protocol.
@@ -99,14 +100,15 @@ type Import struct {
 	Meta    core.Meta `json:"meta"`
 }
 
+//nolint:govet // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 type Entity struct {
-	Kind      EntityKind  `json:"kind,omitempty"`
 	Type      ts.Def      `json:"type"`
 	Component []Component `json:"component,omitempty"`
 	Interface Interface   `json:"interface"`
 	Const     Const       `json:"const"`
-	IsPublic  bool        `json:"exported,omitempty"`
 	Comments  *Comments   `json:"comments,omitempty"`
+	Kind      EntityKind  `json:"kind,omitempty"`
+	IsPublic  bool        `json:"exported,omitempty"`
 }
 
 //nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.

--- a/pkg/ast/flowast.go
+++ b/pkg/ast/flowast.go
@@ -106,6 +106,7 @@ type Entity struct {
 	Interface Interface   `json:"interface"`
 	Const     Const       `json:"const"`
 	IsPublic  bool        `json:"exported,omitempty"`
+	Comments  *Comments   `json:"comments,omitempty"`
 }
 
 //nolint:gocritic // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.


### PR DESCRIPTION
## Summary
- add  with balanced Neva principles and application tracks
- update docs index order in 
- update  Vision pointer text
- add parser-scoped  contract notes
- expand  with compact Neva comments format (, , )

## Notes
- docs/process changes only; no runtime/compiler behavior changes
- related discussion issue: #1114
