### PR TITLE
perf/tooling: optimize streams range and sync golangci-lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.5.0
+          version: latest
           only-new-issues: true
           args: --config=.golangci.yml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.5.0
           only-new-issues: true
           args: --config=.golangci.yml
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # === Development ===
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= latest
 
 # build neva cli for host OS and put to the PATH with `go install`
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # === Development ===
+GOLANGCI_LINT_VERSION ?= v2.5.0
 
 # build neva cli for host OS and put to the PATH with `go install`
 .PHONY: install
@@ -29,7 +30,7 @@ gofix-check:
 
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./...
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 
 .PHONY: test-unit
 test-unit:

--- a/internal/runtime/funcs/range_int.go
+++ b/internal/runtime/funcs/range_int.go
@@ -38,24 +38,16 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 			var (
 				from = fromMsg.Int()
 				//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-				to = toMsg.Int()
-
-				idx  = int64(0)
-				last = false
-				data = from
+				to  = toMsg.Int()
+				idx = int64(0)
 			)
 
-			//nolint:nestif // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
 			if from < to {
-				for !last {
-					if data == to-1 {
-						last = true
-					}
-
+				for data := from; data < to; data++ {
 					item := streamItem(
 						runtime.NewIntMsg(data),
 						idx,
-						last,
+						data == to-1,
 					)
 
 					if !resOut.Send(ctx, item) {
@@ -63,18 +55,13 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 					}
 
 					idx++
-					data++
 				}
 			} else {
-				for !last {
-					if data == toMsg.Int()+1 {
-						last = true
-					}
-
+				for data := from; data > to; data-- {
 					item := streamItem(
 						runtime.NewIntMsg(data),
 						idx,
-						last,
+						data == to+1,
 					)
 
 					if !resOut.Send(ctx, item) {
@@ -82,7 +69,6 @@ func (rangeInt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context),
 					}
 
 					idx++
-					data--
 				}
 			}
 		}

--- a/scripts/hooks/precommit-golangci-fix.sh
+++ b/scripts/hooks/precommit-golangci-fix.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
+: "${GOLANGCI_LINT_VERSION:=v2.5.0}"
+
 files=$(git diff --cached --name-only -- '*.go')
 if [ -z "$files" ]; then
   echo "no staged Go files"
@@ -17,4 +19,4 @@ targets=$(printf '%s\n' "$files" | while IFS= read -r file; do
 done | sort -u)
 
 # shellcheck disable=SC2086
-go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run --fix $targets
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@"$GOLANGCI_LINT_VERSION" run --fix $targets

--- a/scripts/hooks/precommit-golangci-fix.sh
+++ b/scripts/hooks/precommit-golangci-fix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-: "${GOLANGCI_LINT_VERSION:=v2.5.0}"
+: "${GOLANGCI_LINT_VERSION:=latest}"
 
 files=$(git diff --cached --name-only -- '*.go')
 if [ -z "$files" ]; then


### PR DESCRIPTION
## Summary
- optimize  runtime hot loop ()
- unify Smart, fast linters runner.

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  cache       Cache control and information.
  completion  Generate the autocompletion script for the specified shell
  config      Configuration file information and verification.
  custom      Build a version of golangci-lint with custom linters.
  fmt         Format Go source files.
  formatters  List current formatters configuration.
  help        Display extra help
  linters     List current linters configuration.
  migrate     Migrate configuration file from v1 to v2.
  run         Lint the code.
  version     Display the golangci-lint version.

Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
      --version        Print version

Use "golangci-lint [command] --help" for more information about a command. version pin across , pre-commit hook, and CI workflow

## Why
- keep a minimal, independent salvage PR from the larger Msg-representation branch
- reduce local/CI linter version drift

## Validation
- ok  	github.com/nevalang/neva/internal/runtime/funcs	(cached)
