### PR TITLE
release: bump language version to 0.37.0

### DIFF
--- a/pkg/version.go
+++ b/pkg/version.go
@@ -2,4 +2,4 @@ package pkg
 
 // Version is the current version of the language and stdlib.
 // Don't forget to update it before release new tag.
-var Version = "0.36.1" //nolint:gochecknoglobals
+var Version = "0.37.0" //nolint:gochecknoglobals


### PR DESCRIPTION
## Summary
- bump `pkg.Version` from `0.36.1` to `0.37.0`

## Why
- trace support and `pkg/view` foundation have landed; this starts the new minor release line

## Validation
- `go test ./pkg/ast ./internal/compiler/analyzer`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./pkg/... ./internal/compiler/analyzer/...`
