### PR TITLE
runtime: expand Msg scalar list/dict microbench coverage

### DIFF
--- a/internal/runtime/message_bench_test.go
+++ b/internal/runtime/message_bench_test.go
@@ -6,8 +6,10 @@ import (
 )
 
 var (
-	intSink  int64
-	boolSink bool
+	intSink    int64
+	boolSink   bool
+	floatSink  float64
+	stringSink string
 )
 
 //nolint:ireturn // benchmark helper returns runtime.Msg by design.
@@ -140,5 +142,156 @@ func BenchmarkMsgStructGet(b *testing.B) {
 	//nolint:intrange // keeps explicit b.N form for older benchmark style consistency.
 	for i := 0; i < b.N; i++ {
 		intSink = msg.Struct().Get("f31").Int()
+	}
+}
+
+// BenchmarkMsgListIterScalars compares list traversal cost across scalar payload kinds.
+func BenchmarkMsgListIterScalars(b *testing.B) {
+	for _, size := range []int{8, 64, 512, 1024} {
+		b.Run("int_n="+strconv.Itoa(size), func(b *testing.B) { benchListIterInt(b, size) })
+		b.Run("float_n="+strconv.Itoa(size), func(b *testing.B) { benchListIterFloat(b, size) })
+		b.Run("bool_n="+strconv.Itoa(size), func(b *testing.B) { benchListIterBool(b, size) })
+		b.Run("string_n="+strconv.Itoa(size), func(b *testing.B) { benchListIterString(b, size) })
+	}
+}
+
+// BenchmarkMsgDictLookupScalars compares hot-key lookup cost across scalar payload kinds.
+func BenchmarkMsgDictLookupScalars(b *testing.B) {
+	for _, size := range []int{16, 128, 1024} {
+		hotKey := "k" + strconv.Itoa(size-1)
+		b.Run("int_hot_n="+strconv.Itoa(size), func(b *testing.B) { benchDictLookupInt(b, size, hotKey) })
+		b.Run("float_hot_n="+strconv.Itoa(size), func(b *testing.B) { benchDictLookupFloat(b, size, hotKey) })
+		b.Run("bool_hot_n="+strconv.Itoa(size), func(b *testing.B) { benchDictLookupBool(b, size, hotKey) })
+		b.Run("string_hot_n="+strconv.Itoa(size), func(b *testing.B) { benchDictLookupString(b, size, hotKey) })
+	}
+}
+
+func benchListIterInt(b *testing.B, size int) {
+	b.Helper()
+	items := make([]Msg, size)
+	for i := range items {
+		items[i] = NewIntMsg(int64(i))
+	}
+	msg := NewListMsg(items)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var sum int64
+		for _, item := range msg.List() {
+			sum += item.Int()
+		}
+		intSink = sum
+	}
+}
+
+func benchListIterFloat(b *testing.B, size int) {
+	b.Helper()
+	items := make([]Msg, size)
+	for i := range items {
+		items[i] = NewFloatMsg(float64(i) + 0.25)
+	}
+	msg := NewListMsg(items)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var sum float64
+		for _, item := range msg.List() {
+			sum += item.Float()
+		}
+		floatSink = sum
+	}
+}
+
+func benchListIterBool(b *testing.B, size int) {
+	b.Helper()
+	items := make([]Msg, size)
+	for i := range items {
+		items[i] = NewBoolMsg(i%2 == 0)
+	}
+	msg := NewListMsg(items)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var count int64
+		for _, item := range msg.List() {
+			if item.Bool() {
+				count++
+			}
+		}
+		intSink = count
+	}
+}
+
+func benchListIterString(b *testing.B, size int) {
+	b.Helper()
+	items := make([]Msg, size)
+	for i := range items {
+		items[i] = NewStringMsg("v" + strconv.Itoa(i))
+	}
+	msg := NewListMsg(items)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var total int64
+		for _, item := range msg.List() {
+			total += int64(len(item.Str()))
+		}
+		intSink = total
+	}
+}
+
+func benchDictLookupInt(b *testing.B, size int, hotKey string) {
+	b.Helper()
+	entries := make(map[string]Msg, size)
+	for i := range size {
+		entries["k"+strconv.Itoa(i)] = NewIntMsg(int64(i))
+	}
+	msg := NewDictMsg(entries)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		intSink = msg.Dict()[hotKey].Int()
+	}
+}
+
+func benchDictLookupFloat(b *testing.B, size int, hotKey string) {
+	b.Helper()
+	entries := make(map[string]Msg, size)
+	for i := range size {
+		entries["k"+strconv.Itoa(i)] = NewFloatMsg(float64(i) + 0.25)
+	}
+	msg := NewDictMsg(entries)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		floatSink = msg.Dict()[hotKey].Float()
+	}
+}
+
+func benchDictLookupBool(b *testing.B, size int, hotKey string) {
+	b.Helper()
+	entries := make(map[string]Msg, size)
+	for i := range size {
+		entries["k"+strconv.Itoa(i)] = NewBoolMsg(i%2 == 0)
+	}
+	msg := NewDictMsg(entries)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		boolSink = msg.Dict()[hotKey].Bool()
+	}
+}
+
+func benchDictLookupString(b *testing.B, size int, hotKey string) {
+	b.Helper()
+	entries := make(map[string]Msg, size)
+	for i := range size {
+		entries["k"+strconv.Itoa(i)] = NewStringMsg("v" + strconv.Itoa(i))
+	}
+	msg := NewDictMsg(entries)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		stringSink = msg.Dict()[hotKey].Str()
 	}
 }


### PR DESCRIPTION
## Summary
- add dedicated scalar microbenchmarks for list traversal and dict hot-key lookup in 
- cover , , , and  payload scenarios explicitly
- keep benchmarks allocation-focused () with zero-alloc hotpath expectations

## Why
This adds baseline coverage for the exact scalar container scenarios we optimize in runtime Msg work, so main-vs-feature comparisons can be done on matching benchmark suites.

## Validation
- ok  	github.com/nevalang/neva/internal/runtime	0.240s
- goos: darwin
goarch: arm64
pkg: github.com/nevalang/neva/internal/runtime
cpu: Apple M1 Pro
BenchmarkMsgListIterScalars/int_n=8-8         	      20	        56.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/float_n=8-8       	      20	        56.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/bool_n=8-8        	      20	        54.15 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/string_n=8-8      	      20	        60.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/int_n=64-8        	      20	       381.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/float_n=64-8      	      20	       491.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/bool_n=64-8       	      20	       377.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/string_n=64-8     	      20	       377.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/int_n=512-8       	      20	      2746 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/float_n=512-8     	      20	      3650 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/bool_n=512-8      	      20	      2319 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/string_n=512-8    	      20	      2338 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/int_n=1024-8      	      20	      4629 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/float_n=1024-8    	      20	      7367 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/bool_n=1024-8     	      20	      4608 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgListIterScalars/string_n=1024-8   	      20	      4656 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/int_hot_n=16-8  	      20	        37.50 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/float_hot_n=16-8         	      20	        39.55 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/bool_hot_n=16-8          	      20	        37.50 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/string_hot_n=16-8        	      20	        37.50 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/int_hot_n=128-8          	      20	        35.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/float_hot_n=128-8        	      20	        29.20 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/bool_hot_n=128-8         	      20	        29.20 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/string_hot_n=128-8       	      20	        35.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/int_hot_n=1024-8         	      20	        41.70 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/float_hot_n=1024-8       	      20	        35.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/bool_hot_n=1024-8        	      20	        31.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkMsgDictLookupScalars/string_hot_n=1024-8      	      20	        29.15 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/nevalang/neva/internal/runtime	0.258s
- 