### PR TITLE
docs: clarify any and container specialization policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,3 +200,45 @@ We don't have sugar for `maybe<T>` and `list<T>` so why would we have this for u
 However it's not `struct` where we _technically_ have to have some "literal" syntax. It's possible in theory to have just `union<T1, T2, ... Tn>` like e.g. in Python but would require _type-system_ known about `union` name and handle this reference expressions very differently. In fact this will only make design more complicated because we _pretend_ like it's regular type instantiation consisting of reference and arguments but in fact it's not.
 
 Lastly it's just common to have `|` syntax for unions.
+
+### How should we treat `any` in compiler/runtime design?
+
+Practical semantics:
+
+1. `any` is the top type (`T <: any` for any concrete `T`), and `any <: any`.
+2. `any` is intentionally opaque at use sites: do not treat `any` as
+   `int`/`string`/`list`/`dict` without explicit narrowing.
+3. `T: any` remains a valid generic constraint.
+
+This keeps APIs composable without weakening compile-time safety.
+
+### Should `any` be forbidden as a generic type argument?
+
+Current policy: no, not at language level.
+
+`List<any>`, `Dict<string, any>`, or `Foo<any>` are valid but may reduce
+optimization opportunities for runtime container specialization.
+
+Treat this as performance tradeoff, not type-safety violation. If needed,
+enforce later as linter warning, not compiler error.
+
+### How should runtime specialize generic container operations?
+
+Public API should stay generic (for example `Get<T>(List<T>, idx) -> T`), while
+compiler lowering selects internal runtime path by representation kind.
+
+Current practical strategy:
+
+1. Keep fast specialized paths for common scalar containers (`int`, `string`,
+   `bool`, `float`).
+2. Use boxed/generic fallback for complex, nested, union-heavy, or `any`-typed
+   containers unless profiling justifies deeper specialization.
+3. Treat this as implementation detail, not user-visible API split.
+
+This keeps language surface simple and lets performance work evolve
+incrementally.
+
+### Are union tag checks avoidable?
+
+No. Tagged unions are sum types; runtime must inspect discriminants to select a
+case branch. These checks are semantic, not accidental runtime guessing.

--- a/docs/qna.md
+++ b/docs/qna.md
@@ -192,6 +192,47 @@ It reduces code, especially for mappings between records, vectors, and dictionar
 
 Neva's `any` is similar to Go's `any` or TypeScript's `unknown`. It's necessary for certain critical cases where the alternative would be an overly complicated type system.
 
+Practical semantics:
+
+1. `any` is the top type (`T <: any` for any concrete `T`), and `any <: any`.
+2. `any` is intentionally opaque at use sites: you cannot safely treat `any`
+   as `int`/`string`/`list`/`dict` without explicit narrowing.
+3. `T: any` remains a valid generic constraint.
+
+So `any` keeps APIs composable without weakening compile-time safety.
+
+## Should `any` be forbidden as a generic type argument?
+
+Current policy: no, not at language level.
+
+`List<any>`, `Dict<string, any>`, or `Foo<any>` are valid but may reduce
+optimization opportunities for runtime container specialization.
+
+This is treated as a performance tradeoff, not a type-safety violation. If
+needed, this can be enforced later as a linter warning rather than a compiler
+error.
+
+## How should runtime specialize generic container operations?
+
+Public API should stay generic (for example `Get<T>(List<T>, idx) -> T`), while
+compiler lowering selects an internal runtime path by representation kind.
+
+Current practical strategy:
+
+1. Keep fast specialized paths for common scalar containers (`int`, `string`,
+   `bool`, `float`).
+2. Use boxed/generic fallback for complex, nested, union-heavy, or `any`-typed
+   containers unless profiling justifies deeper specialization.
+3. Treat this as an implementation detail, not a user-visible API split.
+
+This keeps language surface simple and allows performance work to evolve
+incrementally.
+
+## Are union tag checks avoidable?
+
+No. Tagged unions are sum types; runtime must inspect discriminants to choose a
+case branch. These checks are semantic, not accidental runtime guessing.
+
 ## How should errors and execution traces relate in Neva?
 
 Treat them as different layers:

--- a/docs/qna.md
+++ b/docs/qna.md
@@ -192,47 +192,6 @@ It reduces code, especially for mappings between records, vectors, and dictionar
 
 Neva's `any` is similar to Go's `any` or TypeScript's `unknown`. It's necessary for certain critical cases where the alternative would be an overly complicated type system.
 
-Practical semantics:
-
-1. `any` is the top type (`T <: any` for any concrete `T`), and `any <: any`.
-2. `any` is intentionally opaque at use sites: you cannot safely treat `any`
-   as `int`/`string`/`list`/`dict` without explicit narrowing.
-3. `T: any` remains a valid generic constraint.
-
-So `any` keeps APIs composable without weakening compile-time safety.
-
-## Should `any` be forbidden as a generic type argument?
-
-Current policy: no, not at language level.
-
-`List<any>`, `Dict<string, any>`, or `Foo<any>` are valid but may reduce
-optimization opportunities for runtime container specialization.
-
-This is treated as a performance tradeoff, not a type-safety violation. If
-needed, this can be enforced later as a linter warning rather than a compiler
-error.
-
-## How should runtime specialize generic container operations?
-
-Public API should stay generic (for example `Get<T>(List<T>, idx) -> T`), while
-compiler lowering selects an internal runtime path by representation kind.
-
-Current practical strategy:
-
-1. Keep fast specialized paths for common scalar containers (`int`, `string`,
-   `bool`, `float`).
-2. Use boxed/generic fallback for complex, nested, union-heavy, or `any`-typed
-   containers unless profiling justifies deeper specialization.
-3. Treat this as an implementation detail, not a user-visible API split.
-
-This keeps language surface simple and allows performance work to evolve
-incrementally.
-
-## Are union tag checks avoidable?
-
-No. Tagged unions are sum types; runtime must inspect discriminants to choose a
-case branch. These checks are semantic, not accidental runtime guessing.
-
 ## How should errors and execution traces relate in Neva?
 
 Treat them as different layers:


### PR DESCRIPTION
## Summary
- document any as top type with opaque usage semantics
- document current policy for any as type argument (allowed, potentially slower)
- document container specialization strategy (scalar fast paths + boxed fallback)
- document why union tag checks are semantic and unavoidable

## Why
This captures design decisions already discussed in perf/runtime threads and reduces ambiguity for future runtime/compiler PRs.

## Scope
Documentation-only change in docs/qna.md.
