### PR TITLE
runtime: add safe Select/list_at coverage and fix bounds panic

### DIFF
--- a/internal/runtime/funcs/list_at.go
+++ b/internal/runtime/funcs/list_at.go
@@ -49,6 +49,7 @@ func (listAt) Create(io runtime.IO, _ runtime.Msg) (func(ctx context.Context), e
 				if !errOut.Send(ctx, errFromString("index out of bounds")) {
 					return
 				}
+				continue
 			}
 
 			if idx < 0 {

--- a/internal/runtime/funcs/list_at_test.go
+++ b/internal/runtime/funcs/list_at_test.go
@@ -1,0 +1,72 @@
+package funcs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nevalang/neva/internal/runtime"
+)
+
+// TestListAtSupportsNegativeIndex verifies invariant: -1 returns the last element.
+func TestListAtSupportsNegativeIndex(t *testing.T) {
+	t.Parallel()
+
+	io, inChans, outChans := newIO([]string{"data", "idx"}, []string{"res", "err"})
+	handler, err := (listAt{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	cancel, done := runHandler(handler)
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	inChans["data"] <- runtime.OrderedMsg{Msg: runtime.NewListMsg([]runtime.Msg{runtime.NewIntMsg(10), runtime.NewIntMsg(20), runtime.NewIntMsg(30)})}
+	inChans["idx"] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(-1)}
+
+	select {
+	case got := <-outChans["res"]:
+		if got.Int() != 30 {
+			t.Fatalf("result = %d, want 30", got.Int())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no result")
+	}
+}
+
+// TestListAtOutOfBounds verifies invariant: out-of-bounds index emits `err`.
+func TestListAtOutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	io, inChans, outChans := newIO([]string{"data", "idx"}, []string{"res", "err"})
+	handler, err := (listAt{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	cancel, done := runHandler(handler)
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	inChans["data"] <- runtime.OrderedMsg{Msg: runtime.NewListMsg([]runtime.Msg{runtime.NewStringMsg("x")})}
+	inChans["idx"] <- runtime.OrderedMsg{Msg: runtime.NewIntMsg(5)}
+
+	select {
+	case got := <-outChans["err"]:
+		if got.Struct().Get("text").Str() != "index out of bounds" {
+			t.Fatalf("error text = %q, want %q", got.Struct().Get("text").Str(), "index out of bounds")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no error result")
+	}
+
+	select {
+	case <-outChans["res"]:
+		t.Fatal("unexpected success result")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/runtime/program_select_bench_test.go
+++ b/internal/runtime/program_select_bench_test.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+// BenchmarkArrayInportSelectTwoSlots measures the two-slot fast-path in Select:
+// one blocking receive + opportunistic competitor probe + index-based ordering.
+func BenchmarkArrayInportSelectTwoSlots(b *testing.B) {
+	ch0 := make(chan OrderedMsg, b.N+1)
+	ch1 := make(chan OrderedMsg, b.N+1)
+	in := newTestArrayInport(ch0, ch1)
+	ctx := context.Background()
+
+	for i := range b.N {
+		ch0 <- OrderedMsg{Msg: NewIntMsg(1), index: uint64(i*2 + 2)}
+		ch1 <- OrderedMsg{Msg: NewIntMsg(2), index: uint64(i*2 + 1)}
+
+		if _, ok := in.Select(ctx); !ok {
+			b.Fatal("unexpected canceled select")
+		}
+		if _, ok := in.Select(ctx); !ok {
+			b.Fatal("unexpected canceled select")
+		}
+	}
+}

--- a/internal/runtime/program_select_test.go
+++ b/internal/runtime/program_select_test.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func newTestArrayInport(chans ...<-chan OrderedMsg) *ArrayInport {
+	return NewArrayInport(
+		NewTracer(),
+		chans,
+		PortAddr{Path: "test/in", Port: "data"},
+		NoEffectInterceptor{},
+	)
+}
+
+func TestArrayInportSelectSingleSlot(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan OrderedMsg, 1)
+	ch <- OrderedMsg{Msg: NewIntMsg(7), index: 10}
+	in := newTestArrayInport(ch)
+
+	selected, ok := in.Select(context.Background())
+	if !ok {
+		t.Fatal("expected message")
+	}
+	if selected.SlotIdx != 0 {
+		t.Fatalf("unexpected slot index: %d", selected.SlotIdx)
+	}
+	if selected.OrderedMsg.Int() != 7 {
+		t.Fatalf("unexpected payload: %d", selected.OrderedMsg.Int())
+	}
+}
+
+func TestArrayInportSelectTwoSlotsOrdersByIndex(t *testing.T) {
+	t.Parallel()
+
+	ch0 := make(chan OrderedMsg, 2)
+	ch1 := make(chan OrderedMsg, 2)
+	ch0 <- OrderedMsg{Msg: NewStringMsg("new"), index: 200}
+	ch1 <- OrderedMsg{Msg: NewStringMsg("old"), index: 100}
+	in := newTestArrayInport(ch0, ch1)
+
+	first, ok := in.Select(context.Background())
+	if !ok {
+		t.Fatal("expected first message")
+	}
+	if first.OrderedMsg.Str() != "old" {
+		t.Fatalf("unexpected first payload: %q", first.OrderedMsg.Str())
+	}
+
+	second, ok := in.Select(context.Background())
+	if !ok {
+		t.Fatal("expected second message")
+	}
+	if second.OrderedMsg.Str() != "new" {
+		t.Fatalf("unexpected second payload: %q", second.OrderedMsg.Str())
+	}
+}
+
+func TestArrayInportSelectContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ch0 := make(chan OrderedMsg)
+	ch1 := make(chan OrderedMsg)
+	in := newTestArrayInport(ch0, ch1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, ok := in.Select(ctx)
+	if ok {
+		t.Fatal("expected select to stop on canceled context")
+	}
+}


### PR DESCRIPTION
## Summary
- add focused tests for ArrayInport.Select ordering/cancel behavior
- add focused tests for list_at invariants (negative index and out-of-bounds)
- add BenchmarkArrayInportSelectTwoSlots
- fix list_at out-of-bounds control-flow bug: after sending err, continue loop instead of indexing invalid position

## Why
This is a safe incremental backport from perf-track work that does not change message representation design in main, but improves correctness coverage and catches a real panic path.

## Validation
- go test ./internal/runtime ./internal/runtime/funcs
