### PR TITLE
Add generative AI policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,14 @@ The language server lives in `nevalang/neva-lsp`, not in this repository.
 ## Documentation
 
 Documentation is organized by primary reader, not by a one-way dependency
-graph. Link between `docs/user/` and `docs/developer/` when useful, but keep a
-topic canonical in one place.
+graph. Keep each topic canonical in one place.
 
 - Public language behavior, API semantics, and Neva style belong in `docs/user/`.
 - Compiler, runtime, standard-library implementation, and test strategy belong
   in `docs/developer/`.
+- User documentation must be self-contained and must not link to developer
+  documentation. Developer documentation may link to user documentation, since
+  contributors are expected to know the public language behavior.
 
 Start from `docs/README.md` for documentation navigation.
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,12 +1,16 @@
 # Developer Documentation
 
 These documents describe how Neva itself is built and maintained. They are
-organized by their primary reader, not by a one-way dependency graph. Link to
-the [user documentation](../user/README.md) whenever it provides the clearest
-explanation of a language concept; keep each topic canonical in one place.
+organized by their primary reader, not by a one-way dependency graph. Keep each
+topic canonical in one place. Developer documentation may link to the [user
+documentation](../user/README.md) when it provides the clearest explanation of
+public language behavior; user documentation must remain self-contained and
+does not link back here.
 
 - **[Architecture](./architecture.md)** - Compiler, runtime, and editor map.
 - **[Contributing](./contributing.md)** - Local setup, release flow, and design rationale.
 - **[Runtime Functions](./runtime-functions.md)** - Native component contracts.
 - **[Compiler](./compiler.md)** - Compiler stages and implementation boundaries.
 - **[Testing](./testing.md)** - Unit, e2e, example, and benchmark coverage.
+- **[Generative AI Policy](./generative-ai-policy.md)** - Contribution
+  responsibility and the project's GenAI direction.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,11 +1,8 @@
 # Developer Documentation
 
-These documents describe how Neva itself is built and maintained. They are
-organized by their primary reader, not by a one-way dependency graph. Keep each
-topic canonical in one place. Developer documentation may link to the [user
-documentation](../user/README.md) when it provides the clearest explanation of
-public language behavior; user documentation must remain self-contained and
-does not link back here.
+These documents describe how Neva itself is built and maintained. See the
+[engineering guide](../../AGENTS.md) for documentation routing and linking
+rules.
 
 - **[Architecture](./architecture.md)** - Compiler, runtime, and editor map.
 - **[Contributing](./contributing.md)** - Local setup, release flow, and design rationale.
@@ -13,4 +10,4 @@ does not link back here.
 - **[Compiler](./compiler.md)** - Compiler stages and implementation boundaries.
 - **[Testing](./testing.md)** - Unit, e2e, example, and benchmark coverage.
 - **[Generative AI Policy](./generative-ai-policy.md)** - Contribution
-  responsibility and the project's GenAI direction.
+  responsibility for AI-assisted changes.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -5,6 +5,8 @@ Neva is a relatively small and simple language, don't be intimidated and feel fr
 Start with [Architecture](./architecture.md), the [engineering guide](../../AGENTS.md),
 and the [Makefile](../../Makefile).
 
+Before opening a pull request, read the [Generative AI Policy](./generative-ai-policy.md).
+
 ## Requirements
 
 - Go: https://go.dev/doc/install

--- a/docs/developer/generative-ai-policy.md
+++ b/docs/developer/generative-ai-policy.md
@@ -1,0 +1,58 @@
+# Generative AI Policy
+
+This policy applies only to the `nevalang/neva` repository. Other Nevalang
+repositories may adopt different policies.
+
+## Contributions
+
+The use of generative AI is neither required nor discouraged. It is a tool,
+like an editor, language server, formatter, autocomplete, or visual editor.
+
+What matters is authorship responsibility. By opening a pull request, a
+contributor represents that they understand every proposed change well enough
+to explain its behavior, trade-offs, limitations, and tests, and to maintain it
+after review.
+
+We do not accept unexamined generated code. In this repository, “vibe coding”
+means delegating implementation to an AI system without personally
+understanding and taking responsibility for the resulting change. That is
+incompatible with review and therefore with merging.
+
+The origin of a change does not lower the bar for correctness, clarity,
+maintainability, testing, or review.
+
+## Neva for AI-Assisted Development
+
+Neva is a general-purpose language, not an AI-first language. Its design is
+intended to remain good for people writing code directly.
+
+At the same time, we want Neva to be an excellent language for coding agents
+and other AI-assisted workflows. The qualities that make code easier for people
+to understand and validate also make it easier for language models to produce
+and repair:
+
+- a small, opinionated core;
+- explicit dataflow and strong static semantics;
+- predictable compilation and useful diagnostics;
+- substantial validation performed by the compiler rather than optional
+  external tooling.
+
+These properties narrow the space of invalid programs and give an agent a
+clear feedback loop: generate, compile, diagnose, and improve. AI assistance
+must never come at the expense of human readability or sound language design.
+
+## Applied GenAI
+
+This is distinct from using AI to write software. We are also interested in
+Neva as a language for building applications that use generative AI: models,
+providers, tokens, context management, long-lived memory, agent protocols, and
+related integrations.
+
+Neva’s core will remain general-purpose. It will not acquire language features
+that make it a specialized GenAI language.
+
+However, thoughtfully designed standard-library packages for applied GenAI may
+be appropriate alongside other practical facilities such as networking, JSON,
+and I/O. Any such API must earn its place through a clear, stable, and
+idiomatic design. No particular package design is promised today, and this work
+should be approached deliberately rather than rushed.

--- a/docs/developer/generative-ai-policy.md
+++ b/docs/developer/generative-ai-policy.md
@@ -21,38 +21,5 @@ incompatible with review and therefore with merging.
 The origin of a change does not lower the bar for correctness, clarity,
 maintainability, testing, or review.
 
-## Neva for AI-Assisted Development
-
-Neva is a general-purpose language, not an AI-first language. Its design is
-intended to remain good for people writing code directly.
-
-At the same time, we want Neva to be an excellent language for coding agents
-and other AI-assisted workflows. The qualities that make code easier for people
-to understand and validate also make it easier for language models to produce
-and repair:
-
-- a small, opinionated core;
-- explicit dataflow and strong static semantics;
-- predictable compilation and useful diagnostics;
-- substantial validation performed by the compiler rather than optional
-  external tooling.
-
-These properties narrow the space of invalid programs and give an agent a
-clear feedback loop: generate, compile, diagnose, and improve. AI assistance
-must never come at the expense of human readability or sound language design.
-
-## Applied GenAI
-
-This is distinct from using AI to write software. We are also interested in
-Neva as a language for building applications that use generative AI: models,
-providers, tokens, context management, long-lived memory, agent protocols, and
-related integrations.
-
-Neva’s core will remain general-purpose. It will not acquire language features
-that make it a specialized GenAI language.
-
-However, thoughtfully designed standard-library packages for applied GenAI may
-be appropriate alongside other practical facilities such as networking, JSON,
-and I/O. Any such API must earn its place through a clear, stable, and
-idiomatic design. No particular package design is promised today, and this work
-should be approached deliberately rather than rushed.
+The language's direction for AI-assisted development and applied GenAI is
+canonical in the [Vision](../user/vision.md#4-ai-native-without-sacrificing-human-authoring).

--- a/docs/user/history.md
+++ b/docs/user/history.md
@@ -66,13 +66,10 @@ Neva is not an AI‑first language. You can write it in nano with zero setup. It
 does not prescribe an authoring workflow or treat AI assistance as a different
 kind of tool.
 
-That said, I'm obsessed with process optimization. If AI can accelerate development, I'm interested. Neva wasn't designed around AI — the core decisions predate coding agents — but it happens to fit them well:
-
-- Minimal core and a small, orthogonal set of abstractions
-- Static typing with relatively strict, predictable compilation rules
-- Human‑readable, deterministic compiler errors
-
-This makes AI output easy to validate: we don't rely on the model's "intuition"; the compiler provides precise feedback loops. Generate code, compile, fix, repeat.
+That said, I'm obsessed with process optimization. If AI can accelerate
+development, I'm interested. Neva wasn't designed around AI — the core
+decisions predate coding agents — but its direction for AI-assisted development
+is described in the [Vision](./vision.md#4-ai-native-without-sacrificing-human-authoring).
 
 ## Neva Programming Language
 

--- a/docs/user/history.md
+++ b/docs/user/history.md
@@ -62,7 +62,9 @@ Programming is hard enough. There's no need to make it harder. Developers should
 
 ## AI-friendly Language
 
-Neva is not an AI‑first language. You can write it in nano with zero setup. I don't prescribe — or even encourage — AI‑generated code.
+Neva is not an AI‑first language. You can write it in nano with zero setup. It
+does not prescribe an authoring workflow or treat AI assistance as a different
+kind of tool.
 
 That said, I'm obsessed with process optimization. If AI can accelerate development, I'm interested. Neva wasn't designed around AI — the core decisions predate coding agents — but it happens to fit them well:
 

--- a/docs/user/vision.md
+++ b/docs/user/vision.md
@@ -46,7 +46,27 @@ Neva should be ergonomic for both:
 1. human-written code (readable, maintainable, explicit);
 2. AI-generated code (predictable, structurally consistent, easy to validate).
 
-AI-native direction must not degrade manual development quality.
+Neva is not an AI-first language: its core remains general-purpose and must
+remain good for people writing code directly. But the same qualities that help
+people understand and validate programs also help coding agents: a small,
+opinionated core; explicit dataflow; strong static semantics; predictable
+compilation; and useful diagnostics. They provide a clear feedback loop:
+generate, compile, diagnose, and improve.
+
+AI-native direction must not degrade manual development quality. It also does
+not mean adding GenAI-specific language features to the core.
+
+### 5) Applied GenAI as a Library Domain
+
+Using AI to write software is distinct from building software that uses
+generative AI. Neva should be a strong option for the latter as well: for
+applications that integrate models, providers, tokens, context management,
+long-lived memory, and agent protocols.
+
+The standard library may eventually provide carefully designed, idiomatic
+packages for this domain, alongside facilities such as networking, JSON, and
+I/O. No particular API is promised today; any additions must be designed
+deliberately and preserve Neva's general-purpose character.
 
 ## Product/Application Tracks
 


### PR DESCRIPTION
## Summary

- add the Neva repository Generative AI Policy
- document the one-way documentation-link rule
- clarify Neva's AI-assisted development and applied GenAI direction

## Validation

- passed: git diff --check
- passed: gofix-check, unit tests, and govulncheck in the pre-push hook
- not run successfully: golangci-lint@latest could not load the Go context in the sandbox; the sandbox also denied its Go module-cache write