### PR TITLE
Update tagged union documentation

### DIFF
--- a/docs/user/book/components.md
+++ b/docs/user/book/components.md
@@ -15,21 +15,25 @@ def And(a bool, b bool) (res bool)
 
 ### Overloading
 
-Native components can be overloaded, allowing multiple implementations with the same signature for different data types. The compiler chooses the appropriate implementation based on the given data type. Overloading is limited to native components in the standard library and not available for user-defined components.
-
-Overloaded native components use a modified extern directive: `#extern(t1 f1, t2 f2, ...)`. These components must have exactly one type parameter with a union constraint. Example:
+Native components can be overloaded by declaring the same component name with
+different concrete signatures. Each declaration has its own ordinary
+`#extern` directive. The compiler selects the compatible declaration.
+Overloading is limited to native components in the standard library and is not
+available for user-defined components.
 
 ```neva
-#extern(int int_add, float float_add, string string_add)
-pub def Add<T int | float | string>(left T, right T) (res T)
+#extern(int_add)
+pub def Add(left int, right int) (res int)
+#extern(float_add)
+pub def Add(left float, right float) (res float)
+#extern(string_add)
+pub def Add(left string, right string) (res string)
 ```
 
 Usage:
 
 ```
-Add<int> // int_add will be used
-Add<float> // float_add will be used
-Add<string> // string_add will be used
+Add // compiler selects the compatible declaration
 ```
 
 ## Normal Components

--- a/docs/user/book/directives.md
+++ b/docs/user/book/directives.md
@@ -13,11 +13,17 @@ pub def Println<T>(data T) (res T, err error)
 
 ### Overloading
 
-Native components can be overloaded using `#extern(t1 f1, t2 f2, ...)`. These components must have one type parameter with a union constraint. The compiler selects the appropriate implementation based on the data type. For instance:
+Overloading uses multiple declarations with the same component name. Each
+declaration has one ordinary `#extern` directive; the compiler selects the
+compatible declaration.
 
 ```neva
-#extern(int int_add, float float_add, string string_add)
-pub def Add<T int | float | string>(left T, right T) (res T)
+#extern(int_add)
+pub def Add(left int, right int) (res int)
+#extern(float_add)
+pub def Add(left float, right float) (res float)
+#extern(string_add)
+pub def Add(left string, right string) (res string)
 ```
 
 ## `#bind`

--- a/docs/user/book/interfaces.md
+++ b/docs/user/book/interfaces.md
@@ -29,26 +29,17 @@ Interfaces in Nevalang are used for:
 interface IAdd(left int, right int) (res int)
 ```
 
-What if we want to add not just integers but also support `float` and `string`? You could use `union` for that
-
-```neva
-type addable int | float | string
-interface IAdd(left addable, right addable) (res addable)
-```
-
-This solution is problematic because it allows mixing types, e.g., `int` for `:left` and `float` for `:right`. The `:res` message will have a union type `int | float | string`, making the code complex. To maintain type-safety, use type-parameters in the interface definition:
+What if we want the same interface to support several types while requiring
+both inputs to have the same type? Use a type parameter:
 
 ```neva
 interface IAdd<T>(left T, right T) (res T)
 ```
 
-This ensures `:left` and `:right` receive compatible types, and `:res` matches their type. However, our current definition allows any type, including `IAdd<bool, bool>`, which we don't want. To fix this, we can explicitly constrain `T` using our union:
-
-```neva
-interface IAdd<T int | float | string>(left T, right T) (res T)
-```
-
-Now only `IAdd<int, int>`, `IAdd<float, float>` or `IAdd<string, string>` (and their compatible variants) are possible. `IAdd:res` will always be `int`, `float`, or `string`.
+This ensures `:left` and `:right` receive compatible types, and `:res` matches
+their type. The current language has tagged unions, not `int | float`-style
+untagged unions; such a scalar-only constraint is therefore not expressible
+with union syntax.
 
 Type-expressions in interface definitions follow type-system rules, so you can pass `T` to other type-expressions. Example:
 

--- a/docs/user/book/types.md
+++ b/docs/user/book/types.md
@@ -19,13 +19,10 @@ streams.ZipResult<int, float> // instantiation with 2 type-arguments
 Type expressions can be infinitely nested:
 
 ```neva
-dict<
-    string,
-    list<struct{
-        foo list<dict<int, float>>
-        bar dict<float, list<int | string>>
-    }>
->
+list<struct {
+    foo list<dict<float>>
+    bar dict<list<int>>
+}>
 ```
 
 ### Literal
@@ -35,8 +32,11 @@ Literal expressions are used for structs and unions, which cannot be expressed a
 ```neva
 struct { a int, b float } // struct with 2 fields
 union { Foo, Bar, Baz } // tagged union with 3 variants
-int | string | float | struct{} // union with 4 elements
 ```
+
+Nevalang has tagged unions only. A union literal declares named tags, and a
+tag can optionally carry a value. It has no `int | string`-style untagged
+union syntax.
 
 ## Definition
 
@@ -49,9 +49,8 @@ Examples:
 type foo int
 // id `bar` with expr `list<T>` and 1 type-param `T`
 type bar<T> list<T>
-// id `baz` with expr `dict<T, Y>`
-// and 2 type-param `T` and `Y`, Y has `int | float` constraint
-type baz<T, Y int | float> dict<T, Y>
+// id `baz` with expr `dict<T>` and 1 type-param `T`
+type baz<T> dict<T>
 ```
 
 With these type definitions, `foo`, `bar`, and `baz` can be used as `int`, `list`, and `dict` respectively.
@@ -83,7 +82,7 @@ Type resolution is the process of reducing type expressions to their base types,
 ```neva
 type foo int
 type bar list<int>
-type baz<T> dict<int, T>
+type baz<T> dict<T>
 type bax<T, Y foo> struct { x T, y baz<Y> }
 ```
 
@@ -128,7 +127,7 @@ Now apply the algorithm to the body:
 ```
 struct { x maybe<float>, y baz<int> }
 // =>
-struct { x maybe<float>, y dict<int, int> }
+struct { x maybe<float>, y dict<int> }
 ```
 
 **Final Result**
@@ -140,7 +139,7 @@ bax<maybe<float>, int>
 // =>
 struct { x maybe<float>, y baz<int> }
 // =>
-struct { x maybe<float>, y dict<int, int> }
+struct { x maybe<float>, y dict<int> }
 ```
 
 ### Type Compatibility
@@ -162,13 +161,6 @@ Struct literal `S1` is compatible with `S2` if `S1` is a superset of `S2` and ea
 #### Tagged Union Literals
 
 Tagged union literal `U1` is compatible with `U2` if `U1` is a subset of `U2` (all variants in `U1` exist in `U2`).
-
-#### Union Literals
-
-Union literal `U1` is compatible with `U2` if:
-
-1. `U1` has fewer or equal elements than `U2`
-2. Each element of `U1` has a compatible element in `U2`
 
 ## Base Types
 


### PR DESCRIPTION
## What changed

- remove obsolete untagged-union (`int | string`) syntax and compatibility rules
- correct `dict<T>` examples
- document tagged-union-only model in type and interface guidance
- correct native overloading examples: repeated declarations with ordinary `#extern`, not a multi-argument directive

## Why

The parser accepts only `struct` and tagged `union { ... }` type literals. The previous documentation described a removed untagged-union syntax and an unsupported `#extern(...)` form.

## Validation

- `go test ./internal/compiler/parser ./internal/compiler/analyzer`
- `git diff --check`

The local pre-push full lint was attempted and blocked by pre-existing lint findings outside this documentation-only diff, including another worktree path. GitHub CI remains required.