### PR TITLE
fix: explain compiler version mismatches

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 
 	cli "github.com/urfave/cli/v2"
 
@@ -56,16 +57,32 @@ func newUpgradeCmd() *cli.Command {
 		Name:  "upgrade",
 		Usage: "Upgrade to newest Nevalang version",
 		Action: func(cliCtx *cli.Context) error {
-			curlCmd := "curl -sSL https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.sh | bash"
-			err := exec.CommandContext(cliCtx.Context, curlCmd).Run()
+			command, args := upgradeCommand(runtime.GOOS)
+			err := exec.CommandContext(cliCtx.Context, command, args...).Run()
 			if err != nil {
-				fmt.Println("Upgrading Nevalang failed :" + err.Error())
+				fmt.Println("Upgrading Nevalang failed: " + err.Error())
 			} else {
-				fmt.Println("Upgrading Nevalang completed. Upgraded to version: " + pkg.Version)
+				fmt.Println("Upgrading Nevalang completed. Restart your terminal or VS Code, then run `neva version` to verify the installed version.")
 			}
 			return nil
 		},
 	}
+}
+
+func upgradeCommand(goos string) (string, []string) {
+	const unixInstaller = "https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.sh"
+	if goos == "windows" {
+		const windowsInstaller = "https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.bat"
+		return "powershell", []string{
+			"-NoProfile",
+			"-Command",
+			"$script = Join-Path $env:TEMP 'neva-install.bat'; " +
+				"Invoke-WebRequest '" + windowsInstaller + "' -OutFile $script; " +
+				"cmd /c $script",
+		}
+	}
+
+	return "sh", []string{"-c", "curl -fsSL " + unixInstaller + " | sh"}
 }
 
 func newGetCmd(workdir string, bldr builder.Builder) *cli.Command {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeCommand(t *testing.T) {
+	command, args := upgradeCommand("darwin")
+	require.Equal(t, "sh", command)
+	require.Equal(t, []string{
+		"-c",
+		"curl -fsSL https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.sh | sh",
+	}, args)
+}
+
+func TestUpgradeCommandWindows(t *testing.T) {
+	command, args := upgradeCommand("windows")
+	require.Equal(t, "powershell", command)
+	require.Equal(t, []string{
+		"-NoProfile",
+		"-Command",
+		"$script = Join-Path $env:TEMP 'neva-install.bat'; " +
+			"Invoke-WebRequest 'https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.bat' -OutFile $script; " +
+			"cmd /c $script",
+	}, args)
+}

--- a/internal/compiler/analyzer/semver.go
+++ b/internal/compiler/analyzer/semver.go
@@ -37,23 +37,13 @@ func (a Analyzer) semverCheck(mod src.Module, modRef core.ModuleRef) *compiler.E
 	// if got major more than ours, then compatibility in that program is broken
 	// and vice versa if got major less than ours
 	if moduleVersion.Major() != compilerVersion.Major() {
-		return &compiler.Error{
-			Message: fmt.Sprintf(
-				"Incompatible compiler versions: module %v wants %v while current is %v",
-				modRef, mod.Manifest.LanguageVersion, pkg.Version,
-			),
-		}
+		return incompatibleCompilerVersionError(modRef, mod.Manifest.LanguageVersion)
 	}
 
 	// if majors are equal, then minor should be less or equal
 	// so we make sure module don't want any features we don't have
 	if moduleVersion.Minor() > compilerVersion.Minor() {
-		return &compiler.Error{
-			Message: fmt.Sprintf(
-				"Incompatible compiler versions: module %v wants %v while current is %v",
-				modRef, mod.Manifest.LanguageVersion, pkg.Version,
-			),
-		}
+		return incompatibleCompilerVersionError(modRef, mod.Manifest.LanguageVersion)
 	}
 
 	// at this point we sure we have same majors and got.Minor >= want.Minor
@@ -71,14 +61,26 @@ func (a Analyzer) semverCheck(mod src.Module, modRef core.ModuleRef) *compiler.E
 	// it's ok if we have some patches that module doesn't rely on
 	// but it's not ok if module a wants some patch we don't really have
 	if moduleVersion.Patch() > compilerVersion.Patch() {
-		return &compiler.Error{
-			Message: fmt.Sprintf(
-				"Incompatible compiler versions: module %v wants %v while current is %v",
-				modRef, mod.Manifest.LanguageVersion, pkg.Version,
-			),
-		}
+		return incompatibleCompilerVersionError(modRef, mod.Manifest.LanguageVersion)
 	}
 
 	// versions are strictly equal
 	return nil
+}
+
+func incompatibleCompilerVersionError(modRef core.ModuleRef, requiredVersion string) *compiler.Error {
+	manifest := "the module manifest (neva.yaml or neva.yml)"
+	module := fmt.Sprintf("module %v", modRef)
+	if modRef.Path == "@" {
+		module = "workspace module @"
+		manifest = "the workspace manifest (neva.yaml or neva.yml)"
+	}
+
+	return &compiler.Error{
+		Message: fmt.Sprintf(
+			"Incompatible compiler versions: %s wants %v while current is %v. "+
+				"Update Neva with `neva upgrade`, or change the `neva:` version in %s.",
+			module, requiredVersion, pkg.Version, manifest,
+		),
+	}
 }

--- a/internal/compiler/analyzer/semver_test.go
+++ b/internal/compiler/analyzer/semver_test.go
@@ -1,0 +1,21 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	src "github.com/nevalang/neva/pkg/ast"
+	"github.com/nevalang/neva/pkg/core"
+)
+
+func TestSemverCheck_ExplainsHowToFixWorkspaceVersionMismatch(t *testing.T) {
+	err := (Analyzer{}).semverCheck(src.Module{
+		Manifest: src.ModuleManifest{LanguageVersion: "99.0.0"},
+	}, core.ModuleRef{Path: "@"})
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Message, "workspace module @")
+	require.Contains(t, err.Message, "neva upgrade")
+	require.Contains(t, err.Message, "neva.yaml or neva.yml")
+}


### PR DESCRIPTION
## What changed
- explain that `@` is the workspace module and point to its `neva.yaml` or `neva.yml` `neva:` field
- suggest `neva upgrade` directly in version-mismatch errors
- make `neva upgrade` execute the installer through a shell instead of treating a pipeline as an executable filename

## Validation
- `go test ./...`
- focused regression tests for mismatch guidance and upgrade command construction