### PR TITLE
fix: install Neva without sudo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
 
 jobs:
+
+  installer_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: test Unix installers
+      run: bash scripts/install_test.sh
+
   unit_tests:
     runs-on: ubuntu-latest
     steps:

--- a/docs/user/tutorial.md
+++ b/docs/user/tutorial.md
@@ -43,6 +43,10 @@ For Mac OS and Linux:
 curl -sSL https://raw.githubusercontent.com/nevalang/neva/main/scripts/install.sh | bash
 ```
 
+The script installs `neva` into `~/.local/bin` by default. Ensure that
+directory is in your `PATH`, then restart your terminal or VS Code. To choose
+another user-writable destination, set `NEVA_INSTALL_DIR` before running it.
+
 If your device is connected to a chinese network:
 
 ```shell

--- a/scripts/china/install.sh
+++ b/scripts/china/install.sh
@@ -1,47 +1,45 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Function to detect platform and architecture
+set -euo pipefail
+
 detect_platform() {
-    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    local arch=$(uname -m)
-    case $arch in
-        x86_64)
-            arch="amd64"
-            ;;
-        arm64|aarch64)
-            arch="arm64"
-            ;;
-        loong64|loongarch64)
-            arch="loong64"
-            ;;
-        *)
-            echo "不支持的架构: $arch"
-            exit 1
-            ;;
-    esac
-    echo "${os}-${arch}"
+	local os arch
+	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	arch=$(uname -m)
+	case "$arch" in
+		x86_64) arch="amd64" ;;
+		arm64|aarch64) arch="arm64" ;;
+		loong64|loongarch64) arch="loong64" ;;
+		*)
+			echo "不支持的架构: $arch" >&2
+			exit 1
+			;;
+	esac
+	printf '%s-%s\n' "$os" "$arch"
 }
 
-# Determine latest release tag
-LATEST_TAG=$(curl -s https://api.github.com/repos/nevalang/neva/releases/latest | grep "tag_name" | cut -d '"' -f 4)
-echo "最新版本: $LATEST_TAG"
+latest_tag=$(curl -fsSL https://api.github.com/repos/nevalang/neva/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+if [[ -z "$latest_tag" ]]; then
+	echo '无法确定最新 Neva 版本。' >&2
+	exit 1
+fi
+echo "最新版本: $latest_tag"
 
-# Determine platform
-PLATFORM=$(detect_platform)
-echo "平台: $PLATFORM"
+platform=$(detect_platform)
+echo "平台: $platform"
 
-# Build the release URL
-BIN_NAME="neva"
-BIN_URL="https://github.moeyy.xyz/https://github.com/nevalang/neva/releases/download/$LATEST_TAG/${BIN_NAME}-${PLATFORM}"
+install_dir="${NEVA_INSTALL_DIR:-$HOME/.local/bin}"
+binary_path="$(mktemp)"
+trap 'rm -f "$binary_path"' EXIT
 
-# Download the binary
-echo "下载中..."
-curl -L $BIN_URL -o $BIN_NAME
+echo '下载中...'
+curl -fL "https://github.moeyy.xyz/https://github.com/nevalang/neva/releases/download/$latest_tag/neva-$platform" -o "$binary_path"
+chmod +x "$binary_path"
+mkdir -p "$install_dir"
+install -m 0755 "$binary_path" "$install_dir/neva"
 
-# Make the binary executable
-chmod +x $BIN_NAME
-
-# Move the binary to a location in the user's PATH
-INSTALL_DIR="/usr/local/bin"
-sudo mv $BIN_NAME $INSTALL_DIR
-echo "已经将 $BIN_NAME 成功安装到 $INSTALL_DIR"
+echo "Neva 已成功安装到 $install_dir/neva"
+case ":$PATH:" in
+	*":$install_dir:"*) ;;
+	*) echo "请将 $install_dir 添加到 PATH，然后重启终端或 VS Code。" ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,47 +1,45 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Function to detect platform and architecture
+set -euo pipefail
+
 detect_platform() {
-    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    local arch=$(uname -m)
-    case $arch in
-        x86_64)
-            arch="amd64"
-            ;;
-        arm64|aarch64)
-            arch="arm64"
-            ;;
-        loong64|loongarch64)
-            arch="loong64"
-          ;;
-        *)
-            echo "Unsupported architecture: $arch"
-            exit 1
-            ;;
-    esac
-    echo "${os}-${arch}"
+	local os arch
+	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	arch=$(uname -m)
+	case "$arch" in
+		x86_64) arch="amd64" ;;
+		arm64|aarch64) arch="arm64" ;;
+		loong64|loongarch64) arch="loong64" ;;
+		*)
+			echo "Unsupported architecture: $arch" >&2
+			exit 1
+			;;
+	esac
+	printf '%s-%s\n' "$os" "$arch"
 }
 
-# Determine latest release tag
-LATEST_TAG=$(curl -s https://api.github.com/repos/nevalang/neva/releases/latest | grep "tag_name" | cut -d '"' -f 4)
-echo "Latest tag is $LATEST_TAG"
+latest_tag=$(curl -fsSL https://api.github.com/repos/nevalang/neva/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+if [[ -z "$latest_tag" ]]; then
+	echo 'Could not determine the latest Neva release tag.' >&2
+	exit 1
+fi
+echo "Latest tag is $latest_tag"
 
-# Determine platform
-PLATFORM=$(detect_platform)
-echo "Platform is $PLATFORM"
+platform=$(detect_platform)
+echo "Platform is $platform"
 
-# Build the release URL
-BIN_NAME="neva"
-BIN_URL="https://github.com/nevalang/neva/releases/download/$LATEST_TAG/${BIN_NAME}-${PLATFORM}"
+install_dir="${NEVA_INSTALL_DIR:-$HOME/.local/bin}"
+binary_path="$(mktemp)"
+trap 'rm -f "$binary_path"' EXIT
 
-# Download the binary
-echo "Downloading..."
-curl -L $BIN_URL -o $BIN_NAME
+echo 'Downloading...'
+curl -fL "https://github.com/nevalang/neva/releases/download/$latest_tag/neva-$platform" -o "$binary_path"
+chmod +x "$binary_path"
+mkdir -p "$install_dir"
+install -m 0755 "$binary_path" "$install_dir/neva"
 
-# Make the binary executable
-chmod +x $BIN_NAME
-
-# Move the binary to a location in the user's PATH
-INSTALL_DIR="/usr/local/bin"
-sudo mv $BIN_NAME $INSTALL_DIR
-echo "$BIN_NAME installed successfully to $INSTALL_DIR"
+echo "Neva installed successfully to $install_dir/neva"
+case ":$PATH:" in
+	*":$install_dir:"*) ;;
+	*) echo "Add $install_dir to PATH, then restart your terminal or VS Code." ;;
+esac

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+mock_bin="$temp_dir/mock-bin"
+mkdir -p "$mock_bin"
+
+printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'if [[ "${MOCK_CURL_FAIL:-}" == 1 ]]; then exit 23; fi' 'if [[ "$*" == *"api.github.com/repos/nevalang/neva/releases/latest"* ]]; then echo '\''{"tag_name":"v9.9.9"}'\''; exit 0; fi' 'while [[ $# -gt 0 ]]; do if [[ "$1" == "-o" ]]; then printf "%s\\n" "#!/usr/bin/env sh" "exit 0" > "$2"; exit 0; fi; shift; done' 'exit 1' > "$mock_bin/curl"
+chmod +x "$mock_bin/curl"
+
+install_dir="$temp_dir/install"
+env HOME="$temp_dir/home" PATH="$mock_bin:$PATH" NEVA_INSTALL_DIR="$install_dir" bash "$repo_root/scripts/install.sh"
+test -x "$install_dir/neva"
+
+if env HOME="$temp_dir/fail-home" PATH="$mock_bin:$PATH" MOCK_CURL_FAIL=1 NEVA_INSTALL_DIR="$temp_dir/fail-install" bash "$repo_root/scripts/install.sh"; then
+	echo 'installer unexpectedly succeeded after a download failure' >&2
+	exit 1
+fi
+test ! -e "$temp_dir/fail-install/neva"


### PR DESCRIPTION
## Summary\n- install Unix binaries into a user-writable directory instead of requiring sudo\n- support NEVA_INSTALL_DIR for an explicit destination\n- fail correctly when release discovery or download fails\n- add a mocked Unix-installer CI test\n\n## Verification\n- bash -n scripts/install.sh scripts/china/install.sh scripts/install_test.sh\n- bash scripts/install_test.sh