### PR TITLE
docs: structure standard library comments

### DIFF
--- a/docs/user/style_guide.md
+++ b/docs/user/style_guide.md
@@ -93,6 +93,8 @@ have at least a short comment explaining their purpose.
   or side effects when they matter to composition. Do not use port tags merely
   to restate a port's type or to describe an abstract value detached from the
   port's behavior.
+- For an interface's single anonymous input or output port, use `_` in place
+  of its name: `@inport _ <text>` or `@outport _ <text>`.
 - When an interface or component uses port tags, document every one of its
   inports and outports.
 - Use `@example <text>` for an external usage example when it makes the

--- a/docs/user/style_guide.md
+++ b/docs/user/style_guide.md
@@ -80,33 +80,39 @@ read:res -> fromBytes -> :res
 
 ## Comments
 
-Good comments explain why.
+Good comments explain the entity's purpose and the behavior a user needs to
+compose it correctly.
 
-Use leading `//` block immediately above entity.
+Use a leading `//` block immediately above an entity. Exported entities should
+have at least a short comment explaining their purpose.
 
-Exported entities should have at least a short leading comment explaining their purpose.
-
-- Free text is allowed and should describe intent/constraints.
-- Use `@inport <name> <text>` for inport semantics.
-- Use `@outport <name> <text>` for outport semantics.
-- Use `@example <text>` for external usage examples (how to use component from outside).
-- Multiple `@example` lines are allowed.
-- Separate logical sections with an empty commented line (`//`).
+- Free text describes intent, constraints, and other entity-level behavior.
+- Use `@inport <name> <text>` and `@outport <name> <text>` for port behavior.
+  Describe when that port receives or sends messages, what those messages mean,
+  and the port's role in the component. Include ordering, completion, errors,
+  or side effects when they matter to composition. Do not use port tags merely
+  to restate a port's type or to describe an abstract value detached from the
+  port's behavior.
+- When an interface or component uses port tags, document every one of its
+  inports and outports.
+- Use `@example <text>` for an external usage example when it makes the
+  component easier to apply. Multiple `@example` lines are allowed.
+- Separate meaningful sections with an empty commented line (`//`).
 
 Example:
 
 ```neva
-// Processes payload and returns normalized result.
-// Keeps stable behavior for repeated start signals.
+// Normalizes each input message after a start signal arrives.
+// Repeated start messages begin independent normalization requests.
 //
-// @inport start Trigger signal.
-// @inport data Input payload.
+// @inport start Starts one normalization request.
+// @inport data Supplies the message normalized by that request.
 //
-// @outport res Normalized payload.
-// @outport err Processing error.
+// @outport res Sends the normalized message when processing succeeds.
+// @outport err Sends the error for a failed request instead of `res`.
 //
 // @example :start -> process:start
-// @example 'hello' -> process:data
+// @example ' hello ' -> process:data
 // @example process:res -> :stop
 def Process(start any, data string) (res string, err error)
 ```

--- a/internal/compiler/parser/comments_helpers.go
+++ b/internal/compiler/parser/comments_helpers.go
@@ -70,6 +70,7 @@ func (s *treeShapeListener) parseLeadingComments(
 	return comments, nil
 }
 
+//nolint:gocognit,cyclop // TODO(strict-lint phase 1): split port-tag handling from generic tags.
 func (s *treeShapeListener) consumeTag(
 	comments *src.Comments,
 	ports *src.IO,
@@ -84,6 +85,11 @@ func (s *treeShapeListener) consumeTag(
 			return s.commentParseError("invalid @inport tag: port name is required", startLine)
 		}
 		if ports != nil {
+			var err *compiler.Error
+			portName, err = s.resolveCommentPortReference(ports.In, portName, "inport", startLine)
+			if err != nil {
+				return err
+			}
 			if _, ok := ports.In[portName]; !ok {
 				return s.commentParseError("unknown @inport reference: "+portName, startLine)
 			}
@@ -95,6 +101,11 @@ func (s *treeShapeListener) consumeTag(
 			return s.commentParseError("invalid @outport tag: port name is required", startLine)
 		}
 		if ports != nil {
+			var err *compiler.Error
+			portName, err = s.resolveCommentPortReference(ports.Out, portName, "outport", startLine)
+			if err != nil {
+				return err
+			}
 			if _, ok := ports.Out[portName]; !ok {
 				return s.commentParseError("unknown @outport reference: "+portName, startLine)
 			}
@@ -111,6 +122,30 @@ func (s *treeShapeListener) consumeTag(
 	}
 
 	return nil
+}
+
+// resolveCommentPortReference maps '_' in a port tag to the single anonymous
+// port. Anonymous ports are only valid when they are the sole port on a side.
+func (s *treeShapeListener) resolveCommentPortReference(
+	ports map[string]src.Port,
+	portName string,
+	tagName string,
+	startLine int,
+) (string, *compiler.Error) {
+	if portName != "_" {
+		return portName, nil
+	}
+
+	if len(ports) == 1 {
+		if _, ok := ports[""]; ok {
+			return "", nil
+		}
+	}
+
+	return "", s.commentParseError(
+		"invalid @"+tagName+" _: '_' may document only a single anonymous port",
+		startLine,
+	)
 }
 
 func (s *treeShapeListener) flushTextBlock(comments *src.Comments, textLines []string) {

--- a/internal/compiler/parser/parser_test.go
+++ b/internal/compiler/parser/parser_test.go
@@ -375,6 +375,38 @@ func TestParser_ParseFile_EntityCommentsUnknownPortFails(t *testing.T) {
 	require.Contains(t, err.Message, "unknown @inport reference")
 }
 
+func TestParser_ParseFile_EntityCommentsAnonymousInterfacePorts(t *testing.T) {
+	text := []byte(`
+		// Transforms one message.
+		//
+		// @inport _ Receives the message to transform.
+		//
+		// @outport _ Sends the transformed message.
+		interface Transform<T, Y>(T) (Y)
+	`)
+
+	p := New()
+	got, err := p.parseFile(location.ModRef, location.Package, location.Filename, text)
+	require.True(t, err == nil)
+
+	comments := got.Entities["Transform"].Comments
+	require.Equal(t, "Receives the message to transform.", comments.Inports[""])
+	require.Equal(t, "Sends the transformed message.", comments.Outports[""])
+}
+
+func TestParser_ParseFile_EntityCommentsAnonymousPortMarkerRequiresAnonymousPort(t *testing.T) {
+	text := []byte(`
+		// @inport _ Does not name an actual port.
+		// @outport res Sends a result.
+		def Process(data any) (res any)
+	`)
+
+	p := New()
+	_, err := p.parseFile(location.ModRef, location.Package, location.Filename, text)
+	require.NotNil(t, err)
+	require.Contains(t, err.Message, "'_' may document only a single anonymous port")
+}
+
 func TestParser_ParseFile_Directives(t *testing.T) {
 	text := []byte(`
 		#extern(d1)

--- a/std/builtin/collections.neva
+++ b/std/builtin/collections.neva
@@ -1,16 +1,43 @@
-// Len returns the length of the given sequence: list, map, or string:
-// for lists it returns number of elements,
-// for maps it returns number of keys,
-// for for strings it returns number of utf-8 characters.
+// Len counts elements, keys, or Unicode code points in a collection.
+//
+// @inport data Receives the list whose elements are counted.
+//
+// @outport res Sends the number of list elements.
 #extern(list_len)
 pub def Len(data list<any>) (res int)
+
+// Len counts elements, keys, or Unicode code points in a collection.
+//
+// @inport data Receives the dictionary whose keys are counted.
+//
+// @outport res Sends the number of dictionary keys.
 #extern(map_len)
 pub def Len(data dict<any>) (res int)
+
+// Len counts elements, keys, or Unicode code points in a collection.
+//
+// @inport data Receives the text whose Unicode code points are counted.
+//
+// @outport res Sends the number of Unicode code points.
 #extern(string_len)
 pub def Len(data string) (res int)
 
-// Slice returns a slice of the given string or list.
+// Slice extracts the selected range from text.
+//
+// @inport data Receives the text sliced by the requested bounds.
+// @inport from Receives the inclusive start index.
+// @inport to Receives the exclusive end index.
+//
+// @outport res Sends the selected text range.
 #extern(string_slice)
 pub def Slice(data string, from int, to int) (res string)
+
+// Slice extracts the selected range from a list.
+//
+// @inport data Receives the list sliced by the requested bounds.
+// @inport from Receives the inclusive start index.
+// @inport to Receives the exclusive end index.
+//
+// @outport res Sends the selected list range.
 #extern(list_slice)
 pub def Slice<T>(data list<T>, from int, to int) (res list<T>)

--- a/std/builtin/core.neva
+++ b/std/builtin/core.neva
@@ -2,10 +2,12 @@
 // It is intended to be used with #bind directive.
 // You should prefer constant references and literals over New.
 // New requires a trigger signal to prevent buffer overflow.
+//
+// @inport sig Receives the trigger for one newly constructed message.
+//
+// @outport res Sends the configured message for that trigger.
 #extern(new)
 pub def New<T>(sig any) (res T)
-
-
 
 // Del receives and discards the message.
 // You should avoid using it because compiler will insert it automatically
@@ -15,6 +17,11 @@ pub def New<T>(sig any) (res T)
 pub def Del(data any) ()
 
 // Lock allows to delay receiving data until a signal arrives.
+//
+// @inport sig Receives the signal that permits the next blocked message.
+// @inport data Receives the message held until a signal arrives.
+//
+// @outport res Sends the held message after the matching signal.
 #extern(lock)
 pub def Lock<T>(sig any, data T) (res T)
 
@@ -25,6 +32,11 @@ pub def Lock<T>(sig any, data T) (res T)
 // - if `true` never arrives, `data` remains blocked
 //
 // This component is event-based (latch-like), not pairwise filtering.
+//
+// @inport data Receives the message held until a true condition arrives.
+// @inport if Receives conditions; false is ignored and true opens the gate.
+//
+// @outport res Sends held data after a true condition opens the gate.
 pub def Gate<T>(data T, if bool) (res T) {
     if If<T>
     lock Lock<T>
@@ -37,12 +49,20 @@ pub def Gate<T>(data T, if bool) (res T) {
 
 // FanIn merges several sources of data into single one.
 // It makes sure order of incoming messages is respected.
+//
+// @inport data Receives messages from each input array slot.
+//
+// @outport res Sends the merged messages while preserving incoming order.
 #extern(fan_in)
 pub def FanIn<T>([data] T) (res T)
 
 // FanOut is used to broadcast a message from one sender to multiple receivers.
 // You should use multiple receivers syntax `-> [...]` instead.
 // Multiple receivers is a syntax sugar over explicit FanOut.
+//
+// @inport data Receives each message broadcast to every output slot.
+//
+// @outport data Sends every received message to each output array slot.
 #extern(fan_out)
 pub def FanOut<T>(data T) ([data] T)
 
@@ -59,25 +79,42 @@ pub def Struct<T struct {}> () (res T)
 // Dot notation is a syntax sugar for Field.
 // Field is unsafe in terms of types because the type system is not sound enough
 // to express "each struct with at least these fields".
+//
+// @inport data Receives the structure whose selected field is read.
+//
+// @outport res Sends the selected field message.
 #extern(field)
 pub def Field<T>(data struct {}) (res T)
 
 // Union wraps data into a union tag.
 // `tag` must be a union literal constant (literal or const ref) identifying the member.
 // `data` must be compatible with the member's type.
+//
+// @inport data Receives the message wrapped in the selected union member.
+// @inport tag Receives the union tag identifying that member.
+//
+// @outport res Sends the tagged union message.
 #extern(union_wrap)
 pub def Union<T Type>(data Type, tag T) (res T)
 
-// Get retrieves a value from a dictionary using the provided key.
-// It has two inports: 'dict' for the dictionary and 'key' for the lookup key.
-// Sends result to 'res' outport, or error to 'err' if key not found.
+// Get retrieves a dictionary message by key.
+//
+// @inport dict Receives the dictionary searched for the key.
+// @inport key Receives the key being looked up.
+//
+// @outport res Sends the matching dictionary message.
+// @outport err Sends an error instead of `res` when the key is absent.
 #extern(get_dict_value_by_key)
 pub def Get<T>(dict dict<T>, key T) (res T, err error)
 
-// Pass is used to pass data through. It receives data and sends it to outport.
+// Pass forwards each message unchanged.
 // E.g. when you want to trigger a constant before fan-in wiring
 // and then use it as a sender in fan-in receiver-side:
 // :start -> 99 -> pass; [pass, receiver2] -> ...
+//
+// @inport data Receives the message forwarded unchanged.
+//
+// @outport res Sends the same message.
 pub def Pass<T>(data T) (res T) {
     :data -> :res
 }
@@ -91,6 +128,11 @@ pub def Pass<T>(data T) (res T) {
 // sends a signal when finishes. Signal could be of any type, so no need for
 // dealing with locks manually. Handler can send error, in that case `Tap` will
 // propagate it up to parent node.
+//
+// @inport data Receives the message passed to the side-effect handler.
+//
+// @outport res Sends the original message after the handler succeeds.
+// @outport err Sends an error emitted by the handler.
 pub def Tap<T>(data T) (res T, err error) {
     handler ITapHandler<T>
     race Race<T>
@@ -102,6 +144,12 @@ pub def Tap<T>(data T) (res T, err error) {
     race:case[1] -> del
 }
 
+// ITapHandler performs the side effect used by Tap.
+//
+// @inport data Receives the message observed by the handler.
+//
+// @outport res Sends a completion message after the side effect succeeds.
+// @outport err Sends an error from the side effect.
 pub interface ITapHandler<T>(T) (res any, err error)
 
 // Enrich runs a handler and returns both the original input and handler result.
@@ -119,12 +167,16 @@ def Enrich<T, Y>(data T) (res EnrichResult<T, Y>, err error) {
     builder -> :res
 }
 
-// EnrichResult is a structure that holds original input
-// and the result of an enrichment operation.
+// EnrichResult holds the original input and an enrichment result.
 type EnrichResult<T, Y> struct {
     data T
     res Y
 }
 
-// IEnrichHandler is an interface for enrich handlers.
+// IEnrichHandler supplies an enrichment result.
+//
+// @inport data Receives the message being enriched.
+//
+// @outport res Sends the enrichment result.
+// @outport err Sends an error when enrichment fails.
 interface IEnrichHandler<T, Y>(data T) (res Y, err error)

--- a/std/builtin/core.neva
+++ b/std/builtin/core.neva
@@ -146,7 +146,7 @@ pub def Tap<T>(data T) (res T, err error) {
 
 // ITapHandler performs the side effect used by Tap.
 //
-// @inport data Receives the message observed by the handler.
+// @inport _ Receives the message observed by the handler.
 //
 // @outport res Sends a completion message after the side effect succeeds.
 // @outport err Sends an error from the side effect.

--- a/std/builtin/operators.neva
+++ b/std/builtin/operators.neva
@@ -1,24 +1,55 @@
 // === UNARY ===
 
 // Not sends true if data is false, and false if data is true.
+//
+// @inport data Receives the boolean inverted by this operation.
+//
+// @outport res Sends the inverted boolean.
 #extern(not)
 pub def Not(data bool) (res bool)
 
 // Inc increments data by 1 and sends to result. Can be used with streams.Map.
+//
+// @inport data Receives the integer incremented by one.
+//
+// @outport res Sends the incremented integer.
 #extern(int_inc)
 pub def Inc(data int) (res int)
+// Inc increments a floating-point message by one.
+//
+// @inport data Receives the floating-point number incremented by one.
+//
+// @outport res Sends the incremented floating-point number.
 #extern(float_inc)
 pub def Inc(data float) (res float)
 
 // Dec decrements data by 1 and sends to result. Can be used with streams.Map.
+//
+// @inport data Receives the integer decremented by one.
+//
+// @outport res Sends the decremented integer.
 #extern(int_dec)
 pub def Dec(data int) (res int)
+// Dec decrements a floating-point message by one.
+//
+// @inport data Receives the floating-point number decremented by one.
+//
+// @outport res Sends the decremented floating-point number.
 #extern(float_dec)
 pub def Dec(data float) (res float)
 
 // Neg negates data and sends to result. Can be used with streams.Map.
+//
+// @inport data Receives the integer whose sign is reversed.
+//
+// @outport res Sends the negated integer.
 #extern(int_neg)
 pub def Neg(data int) (res int)
+// Neg reverses the sign of a floating-point message.
+//
+// @inport data Receives the floating-point number whose sign is reversed.
+//
+// @outport res Sends the negated floating-point number.
 #extern(float_neg)
 pub def Neg(data float) (res float)
 
@@ -27,109 +58,282 @@ pub def Neg(data float) (res float)
 // --- Arithmetic ---
 
 // Add sums left with right and sends to result. It can be used with Reduce.
+//
+// @inport left Receives the first integer addend.
+// @inport right Receives the integer added to `left`.
+//
+// @outport res Sends their sum.
 #extern(int_add)
 pub def Add(left int, right int) (res int)
+// Add sums two floating-point messages.
+//
+// @inport left Receives the first floating-point addend.
+// @inport right Receives the floating-point number added to `left`.
+//
+// @outport res Sends their sum.
 #extern(float_add)
 pub def Add(left float, right float) (res float)
+// Add concatenates two strings.
+//
+// @inport left Receives the string placed first in the result.
+// @inport right Receives the string appended after `left`.
+//
+// @outport res Sends the concatenated string.
 #extern(string_add)
 pub def Add(left string, right string) (res string)
 
 // Sub subtracts right from left and sends to result. It can be used with Reduce.
+//
+// @inport left Receives the integer minuend.
+// @inport right Receives the integer subtracted from `left`.
+//
+// @outport res Sends the difference.
 #extern(int_sub)
 pub def Sub(left int, right int) (res int)
+// Sub subtracts one floating-point message from another.
+//
+// @inport left Receives the floating-point minuend.
+// @inport right Receives the number subtracted from `left`.
+//
+// @outport res Sends the difference.
 #extern(float_sub)
 pub def Sub(left float, right float) (res float)
 
 // Mul multiplies left with right and sends to result. It can be used with Reduce.
+//
+// @inport left Receives the first integer factor.
+// @inport right Receives the integer multiplied by `left`.
+//
+// @outport res Sends the product.
 #extern(int_mul)
 pub def Mul(left int, right int) (res int)
+// Mul multiplies two floating-point messages.
+//
+// @inport left Receives the first floating-point factor.
+// @inport right Receives the number multiplied by `left`.
+//
+// @outport res Sends the product.
 #extern(float_mul)
 pub def Mul(left float, right float) (res float)
 
 // Div divides left by right and sends to result. It can be used with Reduce.
+//
+// @inport left Receives the integer dividend.
+// @inport right Receives the integer divisor.
+//
+// @outport res Sends the quotient.
 #extern(int_div)
 pub def Div(left int, right int) (res int)
+// Div divides one floating-point message by another.
+//
+// @inport left Receives the floating-point dividend.
+// @inport right Receives the floating-point divisor.
+//
+// @outport res Sends the quotient.
 #extern(float_div)
 pub def Div(left float, right float) (res float)
 
 // Mod calculates num modulo den and sends to result.
+//
+// @inport left Receives the integer dividend.
+// @inport right Receives the integer divisor.
+//
+// @outport res Sends the remainder.
 #extern(int_mod)
 pub def Mod(left int, right int) (res int)
 
 // Pow raises left to the power of right and sends to result.
+//
+// @inport left Receives the integer base.
+// @inport right Receives the integer exponent.
+//
+// @outport res Sends the resulting power.
 #extern(int_pow)
 pub def Pow(left int, right int) (res int)
 
 // --- Comparison ---
 
 // Eq sends true if left is equal to right, otherwise false.
+//
+// @inport left Receives the first message compared for equality.
+// @inport right Receives the message compared with `left`.
+//
+// @outport res Sends whether the messages are equal.
 #extern(eq)
 pub def Eq<T>(left T, right T) (res bool)
 
 // Ne sends true if left is not equal to right, otherwise false.
+//
+// @inport left Receives the first message compared for inequality.
+// @inport right Receives the message compared with `left`.
+//
+// @outport res Sends whether the messages differ.
 #extern(ne)
 pub def Ne<T>(left T, right T) (res bool)
 
 // Gt sends true if left is greater than right, otherwise false.
+//
+// @inport left Receives the integer compared with `right`.
+// @inport right Receives the integer compared with `left`.
+//
+// @outport res Sends whether `left` is greater than `right`.
 #extern(int_is_greater)
 pub def Gt(left int, right int) (res bool)
+// Gt compares two floating-point messages.
+//
+// @inport left Receives the floating-point number compared with `right`.
+// @inport right Receives the number compared with `left`.
+//
+// @outport res Sends whether `left` is greater than `right`.
 #extern(float_is_greater)
 pub def Gt(left float, right float) (res bool)
+// Gt compares two strings lexicographically.
+//
+// @inport left Receives the string compared with `right`.
+// @inport right Receives the string compared with `left`.
+//
+// @outport res Sends whether `left` is greater than `right`.
 #extern(string_is_greater)
 pub def Gt(left string, right string) (res bool)
 
 // Lt sends true if left is lesser than right, otherwise false.
+//
+// @inport left Receives the integer compared with `right`.
+// @inport right Receives the integer compared with `left`.
+//
+// @outport res Sends whether `left` is less than `right`.
 #extern(int_is_lesser)
 pub def Lt(left int, right int) (res bool)
+// Lt compares two floating-point messages.
+//
+// @inport left Receives the floating-point number compared with `right`.
+// @inport right Receives the number compared with `left`.
+//
+// @outport res Sends whether `left` is less than `right`.
 #extern(float_is_lesser)
 pub def Lt(left float, right float) (res bool)
+// Lt compares two strings lexicographically.
+//
+// @inport left Receives the string compared with `right`.
+// @inport right Receives the string compared with `left`.
+//
+// @outport res Sends whether `left` is less than `right`.
 #extern(string_is_lesser)
 pub def Lt(left string, right string) (res bool)
 
 // Ge sends true if left is greater than or equal to right, otherwise false.
+//
+// @inport left Receives the integer compared with `right`.
+// @inport right Receives the integer compared with `left`.
+//
+// @outport res Sends whether `left` is greater than or equal to `right`.
 #extern(int_is_greater_or_equal)
 pub def Ge(left int, right int) (res bool)
+// Ge compares two floating-point messages.
+//
+// @inport left Receives the floating-point number compared with `right`.
+// @inport right Receives the number compared with `left`.
+//
+// @outport res Sends whether `left` is greater than or equal to `right`.
 #extern(float_is_greater_or_equal)
 pub def Ge(left float, right float) (res bool)
+// Ge compares two strings lexicographically.
+//
+// @inport left Receives the string compared with `right`.
+// @inport right Receives the string compared with `left`.
+//
+// @outport res Sends whether `left` is greater than or equal to `right`.
 #extern(string_is_greater_or_equal)
 pub def Ge(left string, right string) (res bool)
 
 // Le sends true if left is lesser than or equal to right, otherwise false.
+//
+// @inport left Receives the integer compared with `right`.
+// @inport right Receives the integer compared with `left`.
+//
+// @outport res Sends whether `left` is less than or equal to `right`.
 #extern(int_is_lesser_or_equal)
 pub def Le(left int, right int) (res bool)
+// Le compares two floating-point messages.
+//
+// @inport left Receives the floating-point number compared with `right`.
+// @inport right Receives the number compared with `left`.
+//
+// @outport res Sends whether `left` is less than or equal to `right`.
 #extern(float_is_lesser_or_equal)
 pub def Le(left float, right float) (res bool)
+// Le compares two strings lexicographically.
+//
+// @inport left Receives the string compared with `right`.
+// @inport right Receives the string compared with `left`.
+//
+// @outport res Sends whether `left` is less than or equal to `right`.
 #extern(string_is_lesser_or_equal)
 pub def Le(left string, right string) (res bool)
 
 // --- Logical ---
 
 // And sends true if both left and right are true, otherwise false.
+//
+// @inport left Receives the first boolean condition.
+// @inport right Receives the second boolean condition.
+//
+// @outport res Sends whether both conditions are true.
 #extern(and)
 pub def And(left bool, right bool) (res bool)
 
 // Or sends true if either left or right are true, otherwise false.
+//
+// @inport left Receives the first boolean condition.
+// @inport right Receives the second boolean condition.
+//
+// @outport res Sends whether either condition is true.
 #extern(or)
 pub def Or(left bool, right bool) (res bool)
 
 // --- Bitwise ---
 
 // And performs a binary AND on each bit of two numbers.
+//
+// @inport left Receives the first integer bit pattern.
+// @inport right Receives the integer combined with `left`.
+//
+// @outport res Sends their bitwise AND.
 #extern(int_bitwise_and)
 pub def BitAnd(left int, right int) (res int)
 
 // Or performs a binary OR on each bit of two numbers.
-#extern(int_bitwise_or) 
+//
+// @inport left Receives the first integer bit pattern.
+// @inport right Receives the integer combined with `left`.
+//
+// @outport res Sends their bitwise OR.
+#extern(int_bitwise_or)
 pub def BitOr(left int, right int) (res int)
 
 // Xor performs a binary XOR on each bit of two numbers.
+//
+// @inport left Receives the first integer bit pattern.
+// @inport right Receives the integer combined with `left`.
+//
+// @outport res Sends their bitwise XOR.
 #extern(int_bitwise_xor)
 pub def BitXor(left int, right int) (res int)
 
 // Lsh shifts bits to the left, filling with zeros.
+//
+// @inport left Receives the integer whose bits are shifted.
+// @inport right Receives the number of positions shifted left.
+//
+// @outport res Sends the shifted integer.
 #extern(int_bitwise_lsh)
 pub def BitLsh(left int, right int) (res int)
 
 // Rsh shifts bits to the right, preserving the sign bit.
+//
+// @inport left Receives the integer whose bits are shifted.
+// @inport right Receives the number of positions shifted right.
+//
+// @outport res Sends the shifted integer.
 #extern(int_bitwise_rsh)
 pub def BitRsh(left int, right int) (res int)

--- a/std/builtin/routers.neva
+++ b/std/builtin/routers.neva
@@ -1,4 +1,9 @@
 // If is shorthand for Switch with two cases: true and false.
+//
+// @inport data Receives the boolean that selects an output route.
+//
+// @outport then Sends messages received as true.
+// @outport else Sends messages received as false.
 pub def If<T>(data bool) (then any, else any) {
     switch Switch<bool>
     ---
@@ -10,15 +15,32 @@ pub def If<T>(data bool) (then any, else any) {
 }
 
 // `Cond` is like `If`, but also allows to route data based on a condition.
+//
+// @inport data Receives the message routed by the condition.
+// @inport if Receives the boolean selecting `then` or `else`.
+//
+// @outport then Sends `data` when `if` is true.
+// @outport else Sends `data` when `if` is false.
 #extern(cond)
 pub def Cond<T>(data T, if bool) (then T, else T)
 
 // Switch is a more powerful version of `Cond` that handles multiple cases.
 // Just like `Cond`, it is used for data routing.
 // If you need mapping, use Match or Select instead.
+//
+// @inport data Receives messages compared against the case messages.
+// @inport case Receives the case messages that select matching output slots.
+//
+// @outport case Sends each matched data message through its matching case slot.
+// @outport else Sends data messages that match no case.
 #extern(switch_router)
 pub def Switch<T>(data T, [case] T) ([case] Type, else T)
 
-// Race is like Select but router.
+// Race routes each data message to the slot of the first received case signal.
+//
+// @inport data Receives the messages routed by the next winning case signal.
+// @inport case Receives signals; the first selects its matching output.
+//
+// @outport case Sends data through the output selected by the winning signal.
 #extern(race)
 pub def Race<T>(data T, [case] any) ([case] T)

--- a/std/builtin/scalars.neva
+++ b/std/builtin/scalars.neva
@@ -1,13 +1,25 @@
 // Int converts float to int.
 // Fractional part is discarded (toward zero), like in Go.
+//
+// @inport data Receives the floating-point message to convert.
+//
+// @outport res Sends the converted integer message.
 #extern(int_from_float)
 pub def Int(data float) (res int)
 
 // Float converts int to float, like in Go.
+//
+// @inport data Receives the integer message to convert.
+//
+// @outport res Sends the converted floating-point message.
 #extern(float_from_int)
 pub def Float(data int) (res float)
 
 // String converts int to UTF-8 string by Unicode code point value.
 // This matches Go's string(int) conversion semantics, not decimal formatting.
+//
+// @inport data Receives the integer interpreted as a Unicode code point.
+//
+// @outport res Sends the one-code-point UTF-8 string.
 #extern(string_from_int_codepoint)
 pub def String(data int) (res string)

--- a/std/builtin/selectors.neva
+++ b/std/builtin/selectors.neva
@@ -1,17 +1,35 @@
 // Ternary is a weaker version of Match that only handles 2 cases: true and false.
 // Just like Match, it is used for mapping.
 // If you need routing, use If instead.
+//
+// @inport if Receives the boolean selecting the result message.
+// @inport then Receives the result sent when `if` is true.
+// @inport else Receives the result sent when `if` is false.
+//
+// @outport res Sends the selected result message.
 #extern(ternary)
 pub def Ternary<T>(if bool, then T, else T) (res T)
 
 // Match is a more powerful version of Ternary that handles multiple cases.
 // Just like Ternary it is used for mapping.
 // If you need routing, use `Switch` instead.
+//
+// @inport data Receives the message compared against each case.
+// @inport if Receives case messages associated with result slots.
+// @inport then Receives result messages selected by matching cases.
+// @inport else Receives the fallback result when no case matches.
+//
+// @outport res Sends the selected result message.
 #extern(match)
 pub def Match<T>(data T, [if] T, [then] T, else T) (res T)
 
-// Select allows to select message based on a trigger.
+// Select allows selection of a message based on a trigger.
 // It is useful when it's important where input signal came from.
 // If it's important what the signal is, use `Match` or `Switch` instead.
+//
+// @inport if Receives trigger signals associated with result slots.
+// @inport then Receives result messages selected by their trigger slot.
+//
+// @outport res Sends the result for the trigger that arrives.
 #extern(select)
 pub def Select<T>([if] any, [then] T) (res T)

--- a/std/builtin/types.neva
+++ b/std/builtin/types.neva
@@ -6,6 +6,7 @@ pub type string
 pub type bytes
 pub type dict<T>
 pub type list<T>
+// maybe represents either a present message or no message.
 pub type maybe<T> union {
     Some T
     None
@@ -13,17 +14,20 @@ pub type maybe<T> union {
 
 type Type any
 
+// error carries a human-readable failure and an optional underlying error.
 pub type error struct {
     text string
     child maybe<error>
 }
 
+// stream represents an ordered Open, zero or more Data, then Close protocol.
 pub type stream<T> union {
     Open
     Data T
     Close
 }
 
+// DictEntry carries one key and its associated dictionary message.
 pub type DictEntry<T> struct {
     key string
     value T

--- a/std/bytes/bytes.neva
+++ b/std/bytes/bytes.neva
@@ -1,5 +1,9 @@
 // FromString converts text into raw bytes.
 //
 // This conversion is byte-preserving and does not validate UTF-8.
+//
+// @inport data Receives the text whose encoded bytes are needed.
+//
+// @outport res Sends the bytes of each received text message.
 #extern(bytes_from_string)
 pub def FromString(data string) (res bytes)

--- a/std/dicts/dicts.neva
+++ b/std/dicts/dicts.neva
@@ -2,5 +2,9 @@
 // If the same key appears multiple times, last value wins.
 // It fully materializes input stream, blocks until completion,
 // and may use unbounded memory.
+//
+// @inport data Receives stream entries collected until Close.
+//
+// @outport res Sends the dictionary after the input stream closes.
 #extern(stream_to_dict)
 pub def FromStream<T>(data stream<DictEntry<T>>) (res dict<T>)

--- a/std/errors/errors.neva
+++ b/std/errors/errors.neva
@@ -28,7 +28,7 @@ pub def Must<T, Y>(data T) (res Y) {
 
 // IMustHandler supplies a result or fatal error for Must.
 //
-// @inport data Receives the message handled by Must.
+// @inport _ Receives the message handled by Must.
 //
 // @outport res Sends the successful handler result.
 // @outport err Sends the error that causes Must to panic.
@@ -58,7 +58,7 @@ pub def Lift<T, Y>(data T) (res Y, err error) {
 
 // ILiftHandler supplies a result for Lift without an error path.
 //
-// @inport data Receives the message handled by Lift.
+// @inport _ Receives the message handled by Lift.
 //
-// @outport res Sends the handler result.
+// @outport _ Sends the handler result.
 pub interface ILiftHandler<T, Y>(T) (Y)

--- a/std/errors/errors.neva
+++ b/std/errors/errors.neva
@@ -3,12 +3,20 @@ import {
 }
 
 // New creates a new error with the given text.
+//
+// @inport data Receives the text carried by the new error.
+//
+// @outport res Sends the constructed error.
 #extern(errors_new)
 pub def New(data string) (res error)
 
 // Must converts a node that has an error outport to one that doesn't.
 // It handles the error internally by panicking.
 // Just like Panic, should only be used for fatal errors.
+//
+// @inport data Receives the message passed to the wrapped handler.
+//
+// @outport res Sends the handler result when it succeeds.
 pub def Must<T, Y>(data T) (res Y) {
     handler IMustHandler<T, Y>
     panic runtime.Panic
@@ -18,10 +26,21 @@ pub def Must<T, Y>(data T) (res Y) {
     handler:err -> panic
 }
 
+// IMustHandler supplies a result or fatal error for Must.
+//
+// @inport data Receives the message handled by Must.
+//
+// @outport res Sends the successful handler result.
+// @outport err Sends the error that causes Must to panic.
 pub interface IMustHandler<T, Y>(T) (res Y, err error)
 
 // Lift converts a node that doesn't have an error outport to one that does.
 // The error outport is fictional and will always be silent.
+//
+// @inport data Receives the message passed to the wrapped handler.
+//
+// @outport res Sends the handler result.
+// @outport err Never sends; it makes Lift compatible with error flows.
 pub def Lift<T, Y>(data T) (res Y, err error) {
     handler ILiftHandler<T, Y>
     del Del
@@ -37,4 +56,9 @@ pub def Lift<T, Y>(data T) (res Y, err error) {
     s:else -> del
 }
 
+// ILiftHandler supplies a result for Lift without an error path.
+//
+// @inport data Receives the message handled by Lift.
+//
+// @outport res Sends the handler result.
 pub interface ILiftHandler<T, Y>(T) (Y)

--- a/std/fmt/fmt.neva
+++ b/std/fmt/fmt.neva
@@ -1,8 +1,20 @@
-// Println prints to stdout with newline and then sends message further.
+// Println writes each message to standard output followed by a newline.
+// It then forwards the same message for further processing.
+//
+// @inport data Receives the message written to standard output.
+//
+// @outport res Forwards the written message after output succeeds.
+// @outport err Sends an output error instead of `res` when writing fails.
 #extern(println)
 pub def Println<T>(data T) (res T, err error)
 
-// Print prints to stdout without newline and then sends message further.
+// Print writes each message to standard output without adding a newline.
+// It then forwards the same message for further processing.
+//
+// @inport data Receives the message written to standard output.
+//
+// @outport res Forwards the written message after output succeeds.
+// @outport err Sends an output error instead of `res` when writing fails.
 #extern(print)
 pub def Print<T>(data T) (res T, err error)
 
@@ -10,9 +22,20 @@ pub def Print<T>(data T) (res T, err error)
 // and prints to the standard output.
 // The same argument can be referenced multiple times, but every provided argument
 // must be referenced at least once (otherwise it returns an error).
+//
+// @inport tpl Receives the template whose placeholders select arguments.
+// @inport args Receives the indexed messages substituted into the template.
+//
+// @outport sig Sends a completion signal after the formatted text is written.
+// @outport err Sends a template or output error instead of `sig` on failure.
 #extern(printf)
 pub def Printf(tpl string, [args] any) (sig any, err error)
 
-// Scanln scans text read from the standard input and then sends it further.
+// Scanln reads one line from standard input.
+//
+// @inport sig Receives the signal that starts one line read.
+//
+// @outport res Sends the line read from standard input.
+// @outport err Sends a read error instead of `res` when reading fails.
 #extern(scanln)
 pub def Scanln(sig any) (res string, err error)

--- a/std/http/http.neva
+++ b/std/http/http.neva
@@ -1,7 +1,14 @@
+// Response contains the status code and body returned by an HTTP request.
 pub type Response struct {
 	statusCode int
 	body bytes
 }
 
+// Get performs an HTTP GET request.
+//
+// @inport url Receives the URL requested from the network.
+//
+// @outport res Sends the response after a successful request.
+// @outport err Sends the request error instead of `res` when the request fails.
 #extern(http_get)
 pub def Get(url string) (res Response, err error)

--- a/std/image/image.neva
+++ b/std/image/image.neva
@@ -1,6 +1,6 @@
 // RGBA represents a color in the RGBA 64-bit color space.
 pub type RGBA struct {
-        r int
+	r int
 	g int
 	b int
 	a int
@@ -22,10 +22,20 @@ pub type Image struct {
 	height int
 }
 
-// New creates a new RGBA image from the given pixels.
+// New builds an RGBA image from a stream of pixels.
+//
+// @inport pixels Receives the pixel stream used to build the image.
+//
+// @outport img Sends the image after the pixel stream closes.
+// @outport err Sends an error instead of `img` when image construction fails.
 #extern(image_new)
 pub def New(pixels stream<Pixel>) (img Image, err error)
 
-// Encode a PNG image or return an error.
+// Encode serializes an RGBA image as PNG bytes.
+//
+// @inport img Receives the image encoded as PNG.
+//
+// @outport res Sends the encoded PNG bytes.
+// @outport err Sends an error instead of `res` when PNG encoding fails.
 #extern(image_encode)
 pub def Encode(img Image) (res bytes, err error)

--- a/std/io/io.neva
+++ b/std/io/io.neva
@@ -4,6 +4,11 @@ pub type File int
 // ReadAll reads the file named by filename and returns the contents.
 // It returns an error if the file does not exist or cannot be read.
 // You don't have to think about closing the file, it's done under the hood.
+//
+// @inport filename Receives the path of the file read in full.
+//
+// @outport res Sends the file bytes after a successful read.
+// @outport err Sends a read error instead of `res` when reading fails.
 #extern(read_all)
 pub def ReadAll(filename string) (res bytes, err error)
 
@@ -12,41 +17,86 @@ pub def ReadAll(filename string) (res bytes, err error)
 // If the file does exist, WriteAll truncates it before writing, without changing permissions.
 // It returns an error if the file cannot be written.
 // You don't have to think about closing the file, it's done under the hood.
+//
+// @inport filename Receives the path written or created by this operation.
+// @inport data Receives the bytes written to that path.
+//
+// @outport res Sends a completion signal after all bytes are written.
+// @outport err Sends a write error instead of `res` when the operation fails.
 #extern(write_all)
 pub def WriteAll(filename string, data bytes) (res any, err error)
 
 // Open opens a file for reading and returns a file handle.
 // Handles must be closed explicitly with Close.
+//
+// @inport filename Receives the path opened for reading.
+//
+// @outport res Sends the handle that remains open until Close receives it.
+// @outport err Sends an open error instead of `res` when opening fails.
 #extern(file_open)
 pub def Open(filename string) (res File, err error)
 
 // Create creates (or truncates) a file for writing and returns a file handle.
 // Handles must be closed explicitly with Close.
+//
+// @inport filename Receives the path created or truncated for writing.
+//
+// @outport res Sends the handle that remains open until Close receives it.
+// @outport err Sends a creation error instead of `res` when opening fails.
 #extern(file_create)
 pub def Create(filename string) (res File, err error)
 
 // Close releases a file handle returned by Open/Create.
+//
+// @inport file Receives the open handle released by this operation.
+//
+// @outport res Sends a completion signal after the handle closes.
+// @outport err Sends a close error instead of `res` when closing fails.
 #extern(file_close)
 pub def Close(file File) (res any, err error)
 
 // Stdin returns the process stdin file handle.
+//
+// @inport sig Receives the signal that requests the standard-input handle.
+//
+// @outport res Sends the process standard-input handle.
 #extern(file_stdin)
 pub def Stdin(sig any) (res File)
 
 // Stdout returns the process stdout file handle.
+//
+// @inport sig Receives the signal that requests the standard-output handle.
+//
+// @outport res Sends the process standard-output handle.
 #extern(file_stdout)
 pub def Stdout(sig any) (res File)
 
 // Stderr returns the process stderr file handle.
+//
+// @inport sig Receives the signal that requests the standard-error handle.
+//
+// @outport res Sends the process standard-error handle.
 #extern(file_stderr)
 pub def Stderr(sig any) (res File)
 
 // ReadAllFile reads all bytes from a previously opened file handle.
 // It also passes the same handle further so it can be chained into Close.
+//
+// @inport file Receives the open handle read to completion.
+//
+// @outport res Sends the bytes read from the handle.
+// @outport handle Sends the same still-open handle for a subsequent operation.
+// @outport err Sends a read error instead of `res` when reading fails.
 #extern(file_read_all)
 pub def ReadAllFile(file File) (res bytes, handle File, err error)
 
 // WriteAllFile writes the provided bytes to a previously created file handle.
 // It returns the same handle so it can be chained into Close.
+//
+// @inport file Receives the open handle written by this operation.
+// @inport data Receives the bytes written to that handle.
+//
+// @outport res Sends the same still-open handle after writing succeeds.
+// @outport err Sends a write error instead of `res` when writing fails.
 #extern(file_write_all)
 pub def WriteAllFile(file File, data bytes) (res File, err error)

--- a/std/lists/lists.neva
+++ b/std/lists/lists.neva
@@ -1,23 +1,53 @@
 // FromStream fully materializes stream into list.
 // It blocks until the stream is completed and may use unbounded memory.
+//
+// @inport data Receives stream messages collected until Close.
+//
+// @outport res Sends the list after the input stream closes.
 #extern(stream_to_list)
 pub def FromStream<T>(data stream<T>) (res list<T>)
 
 // FromArray iterates over all array-inport's slots in order and returns a list.
+//
+// @inport port Receives messages from each array slot in slot order.
+//
+// @outport res Sends one list containing the messages from every slot.
 #extern(array_port_to_list)
 pub def FromArray<T>([port] T) (res list<T>)
 
 // Append creates new list with appended element.
+//
+// @inport lst Receives the list extended by the following data message.
+// @inport data Receives the element added after the existing list items.
+//
+// @outport res Sends the newly extended list.
 #extern(list_append)
 pub def Append<T>(lst list<T>, data T) (res list<T>)
 
 // Prepend creates new list with data before all existing elements.
+//
+// @inport lst Receives the list extended by the preceding data message.
+// @inport data Receives the element added before the existing list items.
+//
+// @outport res Sends the newly extended list.
 #extern(list_prepend)
 pub def Prepend<T>(lst list<T>, data T) (res list<T>)
 
 // Concat creates a new list by combining left followed by right.
+//
+// @inport left Receives the list placed first in the result.
+// @inport right Receives the list appended after `left`.
+//
+// @outport res Sends the combined list.
 #extern(list_concat)
 pub def Concat<T>(left list<T>, right list<T>) (res list<T>)
 
+// At retrieves the item at a list index.
+//
+// @inport data Receives the list searched for an item.
+// @inport idx Receives the index of the requested item.
+//
+// @outport res Sends the item at that index.
+// @outport err Sends an error instead of `res` when the index is out of range.
 #extern(list_at)
 pub def At<T>(data list<T>, idx int) (res T, err error)

--- a/std/os/dotenv/dotenv.neva
+++ b/std/os/dotenv/dotenv.neva
@@ -1,32 +1,42 @@
 // Package dotenv loads environment variables from dotenv files into the
 // current process environment.
 
-// LoadFrom loads environment variables from the provided dotenv file path.
-// The input port "data" is the filename to load from. It does not override
-// existing environment variables. The output port "res" sends a signal when
-// loading completes. If you want to load from the default ".env" in the
-// working directory, use Load instead.
+// LoadFrom loads a dotenv file without replacing existing environment values.
+// Use Load for the default `.env` file in the working directory.
+//
+// @inport data Receives the dotenv file path loaded into the environment.
+//
+// @outport res Sends a completion signal after the file is loaded.
+// @outport err Sends a read or parse error instead of `res` when loading fails.
 #extern(dotenv_load_from)
 pub def LoadFrom(data string) (res any, err error)
 
-// Load loads environment variables from ".env" in the working directory.
-// It does not override existing environment variables. The output port "res"
-// sends a signal when loading completes. If you need to load a specific path,
-// use LoadFrom instead.
+// Load loads `.env` without replacing existing environment values.
+// Use LoadFrom when the dotenv file has a different path.
+//
+// @inport sig Receives the signal that starts loading the default dotenv file.
+//
+// @outport res Sends a completion signal after the file is loaded.
+// @outport err Sends a read or parse error instead of `res` when loading fails.
 #extern(dotenv_load)
 pub def Load(sig any) (res any, err error)
 
-// LoadFromOverride loads environment variables from the provided dotenv file
-// path and overrides existing environment variables. The input port "data" is
-// the filename to load from. The output port "res" sends a signal when loading
-// completes. If you want to override using the default ".env" path, use
-// LoadOverride instead.
+// LoadFromOverride loads a dotenv file and replaces environment values.
+// Use LoadOverride for the default `.env` file in the working directory.
+//
+// @inport data Receives the dotenv file path loaded into the environment.
+//
+// @outport res Sends a completion signal after the file is loaded.
+// @outport err Sends a read or parse error instead of `res` when loading fails.
 #extern(dotenv_load_from_override)
 pub def LoadFromOverride(data string) (res any, err error)
 
-// LoadOverride loads environment variables from ".env" in the working
-// directory and overrides existing environment variables. The output port
-// "res" sends a signal when loading completes. If you need to override values
-// from a specific path, use LoadFromOverride instead.
+// LoadOverride loads `.env` and replaces existing environment values.
+// Use LoadFromOverride when the dotenv file has a different path.
+//
+// @inport sig Receives the signal that starts loading the default dotenv file.
+//
+// @outport res Sends a completion signal after the file is loaded.
+// @outport err Sends a read or parse error instead of `res` when loading fails.
 #extern(dotenv_load_override)
 pub def LoadOverride(sig any) (res any, err error)

--- a/std/os/os.neva
+++ b/std/os/os.neva
@@ -20,6 +20,10 @@ pub type FileInfo struct {
 }
 
 // Args returns command-line arguments.
+//
+// @inport sig Receives the signal that requests the process arguments.
+//
+// @outport res Sends the complete command-line argument list.
 #extern(args)
 pub def Args(sig any) (res list<string>)
 
@@ -32,101 +36,225 @@ pub def Exit(code int) ()
 // It returns a list of strings (not a stream) because the runtime function
 // produces a full list at once. If you need only specific values, filter the
 // returned list in your flow.
+//
+// @inport sig Receives the signal that requests the current environment.
+//
+// @outport res Sends the complete KEY=VALUE environment list.
 #extern(os_environ)
 pub def Environ(sig any) (res list<string>)
 
 // Getenv returns the value of environment variable key.
+//
+// @inport key Receives the environment-variable name to look up.
+//
+// @outport res Sends its text, or an empty string when it is unset.
 #extern(os_getenv)
 pub def Getenv(key string) (res string)
 
 // LookupEnv returns the value and existence flag for environment variable key.
+//
+// @inport key Receives the environment-variable name to look up.
+//
+// @outport res Sends the variable value together with whether it exists.
 #extern(os_lookup_env)
 pub def LookupEnv(key string) (res LookupEnvResult)
 
 // Setenv sets environment variable key to value.
+//
+// @inport key Receives the name of the environment variable updated.
+// @inport value Receives the text assigned to that variable.
+//
+// @outport res Sends a completion signal after the process environment changes.
+// @outport err Sends an update error instead of `res` when the name is invalid.
 #extern(os_setenv)
 pub def Setenv(key string, value string) (res any, err error)
 
 // Unsetenv unsets environment variable key.
+//
+// @inport key Receives the name of the environment variable removed.
+//
+// @outport res Sends a completion signal after the variable is removed.
+// @outport err Sends an update error instead of `res` when the name is invalid.
 #extern(os_unsetenv)
 pub def Unsetenv(key string) (res any, err error)
 
 // Clearenv deletes all environment variables.
+//
+// @inport sig Receives the signal that clears the process environment.
+//
+// @outport res Sends a completion signal after all variables are removed.
 #extern(os_clearenv)
 pub def Clearenv(sig any) (res any)
 
 // ExpandEnv replaces ${var} and $var with environment values.
+//
+// @inport data Receives the text containing environment-variable references.
+//
+// @outport res Sends the text after references are expanded.
 #extern(os_expand_env)
 pub def ExpandEnv(data string) (res string)
 
 // Getwd returns the current working directory.
+//
+// @inport sig Receives the signal that requests the current directory.
+//
+// @outport res Sends the process working-directory path.
+// @outport err Sends an error instead of `res` when lookup fails.
 #extern(os_getwd)
 pub def Getwd(sig any) (res string, err error)
 
 // Chdir changes the current working directory.
+//
+// @inport path Receives the directory that becomes the working directory.
+//
+// @outport res Sends a completion signal after the directory changes.
+// @outport err Sends an error instead of `res` when changing directories fails.
 #extern(os_chdir)
 pub def Chdir(path string) (res any, err error)
 
 // Getpid returns process identifier.
+//
+// @inport sig Receives the signal that requests the process identifier.
+//
+// @outport res Sends the current process identifier.
 #extern(os_getpid)
 pub def Getpid(sig any) (res int)
 
 // Getppid returns the parent process identifier.
+//
+// @inport sig Receives the signal that requests the parent process identifier.
+//
+// @outport res Sends the parent process identifier.
 #extern(os_getppid)
 pub def Getppid(sig any) (res int)
 
 // Hostname returns the host name.
+//
+// @inport sig Receives the signal that requests the host name.
+//
+// @outport res Sends the current host name.
+// @outport err Sends an error instead of `res` when lookup fails.
 #extern(os_hostname)
 pub def Hostname(sig any) (res string, err error)
 
 // Executable returns path of the running executable.
+//
+// @inport sig Receives the signal that requests the executable path.
+//
+// @outport res Sends the path of the running executable.
+// @outport err Sends an error instead of `res` when the path is unavailable.
 #extern(os_executable)
 pub def Executable(sig any) (res string, err error)
 
 // Mkdir creates a directory with provided permissions.
+//
+// @inport path Receives the directory path created by this operation.
+// @inport perm Receives the permission bits assigned to the new directory.
+//
+// @outport res Sends a completion signal after the directory is created.
+// @outport err Sends a creation error instead of `res` when it fails.
 #extern(os_mkdir)
 pub def Mkdir(path string, perm int) (res any, err error)
 
 // MkdirAll creates a directory path and parents with provided permissions.
+//
+// @inport path Receives the directory path and missing parents to create.
+// @inport perm Receives the permission bits assigned to created directories.
+//
+// @outport res Sends a completion signal after the directory tree exists.
+// @outport err Sends a creation error instead of `res` when it fails.
 #extern(os_mkdir_all)
 pub def MkdirAll(path string, perm int) (res any, err error)
 
 // ReadDir reads directory entries sorted by filename.
+//
+// @inport path Receives the directory path whose entries are listed.
+//
+// @outport res Sends the entries sorted by filename.
+// @outport err Sends a read error instead of `res` when listing fails.
 #extern(os_read_dir)
 pub def ReadDir(path string) (res list<DirEntry>, err error)
 
 // Remove removes path.
+//
+// @inport path Receives the file or empty directory path removed.
+//
+// @outport res Sends a completion signal after the path is removed.
+// @outport err Sends a removal error instead of `res` when it fails.
 #extern(os_remove)
 pub def Remove(path string) (res any, err error)
 
 // RemoveAll removes path and all children recursively.
+//
+// @inport path Receives the path whose entire tree is removed.
+//
+// @outport res Sends a completion signal after recursive removal finishes.
+// @outport err Sends a removal error instead of `res` when it fails.
 #extern(os_remove_all)
 pub def RemoveAll(path string) (res any, err error)
 
 // Rename renames or moves oldPath to newPath.
+//
+// @inport oldPath Receives the existing path renamed or moved.
+// @inport newPath Receives the destination path.
+//
+// @outport res Sends a completion signal after the rename succeeds.
+// @outport err Sends a rename error instead of `res` when it fails.
 #extern(os_rename)
 pub def Rename(oldPath string, newPath string) (res any, err error)
 
 // Stat returns file information for path.
+//
+// @inport path Receives the path inspected while following symlinks.
+//
+// @outport res Sends the file information for that path.
+// @outport err Sends a lookup error instead of `res` when inspection fails.
 #extern(os_stat)
 pub def Stat(path string) (res FileInfo, err error)
 
 // Lstat returns file information for path without following symlinks.
+//
+// @inport path Receives the path inspected without following its final symlink.
+//
+// @outport res Sends the file information for that path.
+// @outport err Sends a lookup error instead of `res` when inspection fails.
 #extern(os_lstat)
 pub def Lstat(path string) (res FileInfo, err error)
 
 // Truncate changes size of the named file.
+//
+// @inport path Receives the file path resized by this operation.
+// @inport size Receives the target size in bytes.
+//
+// @outport res Sends a completion signal after the file size changes.
+// @outport err Sends a resize error instead of `res` when it fails.
 #extern(os_truncate)
 pub def Truncate(path string, size int) (res any, err error)
 
 // TempDir returns default directory for temporary files.
+//
+// @inport sig Receives the signal that requests the default temporary path.
+//
+// @outport res Sends the default temporary-directory path.
 #extern(os_temp_dir)
 pub def TempDir(sig any) (res string)
 
 // MkdirTemp creates a new temporary directory.
+//
+// @inport dir Receives the parent path, or an empty string for the default.
+// @inport pattern Receives the name pattern for the temporary directory.
+//
+// @outport res Sends the path of the newly created directory.
+// @outport err Sends a creation error instead of `res` when it fails.
 #extern(os_mkdir_temp)
 pub def MkdirTemp(dir string, pattern string) (res string, err error)
 
 // CreateTemp creates a new temporary file and returns its name.
+//
+// @inport dir Receives the parent path, or an empty string for the default.
+// @inport pattern Receives the name pattern for the temporary file.
+//
+// @outport res Sends the path of the newly created file.
+// @outport err Sends a creation error instead of `res` when it fails.
 #extern(os_create_temp)
 pub def CreateTemp(dir string, pattern string) (res string, err error)

--- a/std/regexp/regexp.neva
+++ b/std/regexp/regexp.neva
@@ -1,2 +1,10 @@
+// Submatch matches each text message against a regular expression.
+// It reports an error when the expression cannot be compiled.
+//
+// @inport regexp Receives the regular expression used for a match.
+// @inport data Receives the text matched against that expression.
+//
+// @outport res Sends the full match and captured submatches.
+// @outport err Sends a compilation error instead of `res` for invalid syntax.
 #extern(regexp_submatch)
 pub def Submatch(regexp string, data string) (res list<string>, err error)

--- a/std/runtime/runtime.neva
+++ b/std/runtime/runtime.neva
@@ -1,6 +1,6 @@
 // Runtime package contains components that can interact with the runtime.
 
-// Panic immidiately terminates the program after message is received.
+// Panic immediately terminates the program after receiving a message.
 // Panic and Del are the only components without outports.
 #extern(panic)
 pub def Panic(data any) ()

--- a/std/strconv/strconv.neva
+++ b/std/strconv/strconv.neva
@@ -7,35 +7,78 @@
 
 // ParseBool returns the boolean value represented by the string.
 // It accepts Go-compatible values: 1,t,T,TRUE,true,True,0,f,F,FALSE,false,False.
+//
+// @inport data Receives the text parsed as a boolean.
+//
+// @outport res Sends the parsed boolean.
+// @outport err Sends a parse error instead of `res` for unsupported text.
 #extern(parse_bool)
 pub def ParseBool(data string) (res bool, err error)
 
 // FormatBool returns "true" or "false" according to the boolean input.
+//
+// @inport data Receives the boolean formatted as text.
+//
+// @outport res Sends `true` or `false`.
 #extern(format_bool)
 pub def FormatBool(data bool) (res string)
 
 // Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.
+//
+// @inport data Receives base-10 text parsed as an integer.
+//
+// @outport res Sends the parsed integer.
+// @outport err Sends a parse error instead of `res` for invalid text.
 #extern(atoi)
 pub def Atoi(data string) (res int, err error)
 
 // Itoa is equivalent to FormatInt(i, 10).
+//
+// @inport data Receives the integer formatted in base 10.
+//
+// @outport res Sends the base-10 text.
 #extern(itoa)
 pub def Itoa(data int) (res string)
 
-// ParseInt parses an integer from a string `data` with given `base` (2, 8, 10, 16).
+// ParseInt parses an integer from text in the requested base and bit size.
+//
+// @inport data Receives the text parsed as an integer.
+// @inport base Receives the numerical base accepted by Go strconv parsing.
+// @inport bits Receives the target integer bit size.
+//
+// @outport res Sends the parsed integer.
+// @outport err Sends a parse error instead of `res` for invalid text or bounds.
 #extern(parse_int)
 pub def ParseInt(data string, base int, bits int) (res int, err error)
 
 // FormatInt formats integer `data` in provided `base`.
 // The base should follow Go's strconv.FormatInt rules (2 to 36).
+//
+// @inport data Receives the integer formatted as text.
+// @inport base Receives the base used for the textual representation.
+//
+// @outport res Sends the formatted integer text.
 #extern(format_int)
 pub def FormatInt(data int, base int) (res string)
 
-// ParseFloat parses a float from a string `data` with given `bits` (32 or 64).
+// ParseFloat parses a floating-point number at the requested precision.
+//
+// @inport data Receives the text parsed as a floating-point number.
+// @inport bits Receives the target floating-point bit size.
+//
+// @outport res Sends the parsed floating-point number.
+// @outport err Sends a parse error instead of `res` for invalid text or bounds.
 #extern(parse_float)
 pub def ParseFloat(data string, bits int) (res float, err error)
 
 // FormatFloat formats float using Go strconv.FormatFloat semantics.
 // `fmt` verbs: b, e, E, f, g, G, x, X.
+//
+// @inport data Receives the floating-point number formatted as text.
+// @inport fmt Receives the formatting verb.
+// @inport prec Receives the precision interpreted by the selected verb.
+// @inport bits Receives the source floating-point bit size.
+//
+// @outport res Sends the formatted floating-point text.
 #extern(format_float)
 pub def FormatFloat(data float, fmt string, prec int, bits int) (res string)

--- a/std/streams/filter.neva
+++ b/std/streams/filter.neva
@@ -4,6 +4,10 @@ import {
 
 // Filter filters a stream based on a predicate.
 // It produces a new stream containing only the elements that satisfy the predicate.
+//
+// @inport data Receives the stream whose Data messages are tested.
+//
+// @outport res Sends boundaries and Data messages accepted by the predicate.
 pub def Filter<T>(data stream<T>) (res stream<T>) {
 	split Split<T>{predicate IPredicate<T>}
 	---
@@ -12,6 +16,11 @@ pub def Filter<T>(data stream<T>) (res stream<T>) {
 }
 
 // Split splits a stream into two streams based on a predicate.
+//
+// @inport data Receives the stream whose Data messages are classified.
+//
+// @outport then Sends boundaries and Data messages accepted by the predicate.
+// @outport else Sends boundaries and Data messages rejected by the predicate.
 pub def Split<T>(data stream<T>) (then stream<T>, else stream<T>) {
 	turn sync.Turn<stream<T>>
 	classify Classify<T>{predicate IPredicate<T>}
@@ -83,6 +92,10 @@ def Emit<T>(data stream<T>, condition bool) (then stream<T>, else stream<T>, don
 	done_output -> :done
 }
 
-// IPredicate represents a logic that determines if a value satisfies a condition.
-// It is used by components like Filter and Split to decide how to process stream elements.
+// IPredicate decides whether a stream Data message is accepted.
+// It is used by Filter and Split.
+//
+// @inport data Receives the Data message being classified.
+//
+// @outport res Sends whether that message satisfies the predicate.
 pub interface IPredicate<T>(T) (bool)

--- a/std/streams/filter.neva
+++ b/std/streams/filter.neva
@@ -95,7 +95,7 @@ def Emit<T>(data stream<T>, condition bool) (then stream<T>, else stream<T>, don
 // IPredicate decides whether a stream Data message is accepted.
 // It is used by Filter and Split.
 //
-// @inport data Receives the Data message being classified.
+// @inport _ Receives the Data message being classified.
 //
-// @outport res Sends whether that message satisfies the predicate.
+// @outport _ Sends whether that message satisfies the predicate.
 pub interface IPredicate<T>(T) (bool)

--- a/std/streams/for_each.neva
+++ b/std/streams/for_each.neva
@@ -10,6 +10,11 @@ import {
 // This prevents concurrency issues in side-effecting handlers.
 //
 // To wait for all items to be processed, use it with streams.Wait.
+//
+// @inport data Receives the stream whose Data messages invoke the handler.
+//
+// @outport res Forwards the original Open/Data/Close stream in handler order.
+// @outport err Sends an error emitted by a handler invocation.
 pub def ForEach<T>(data stream<T>) (res stream<T>, err error) {
 	turn sync.Turn<stream<T>>
 	hold Lock<stream<T>>
@@ -34,5 +39,10 @@ pub def ForEach<T>(data stream<T>) (res stream<T>, err error) {
 	hold -> [turn:done, :res]
 }
 
-// IForEachHandler is a dependency for ForEach.
+// IForEachHandler performs one side effect for ForEach.
+//
+// @inport data Receives one input stream Data message.
+//
+// @outport res Sends a completion message that permits the next stream item.
+// @outport err Sends an error from that handler invocation.
 pub interface IForEachHandler<T>(T) (res any, err error)

--- a/std/streams/for_each.neva
+++ b/std/streams/for_each.neva
@@ -41,7 +41,7 @@ pub def ForEach<T>(data stream<T>) (res stream<T>, err error) {
 
 // IForEachHandler performs one side effect for ForEach.
 //
-// @inport data Receives one input stream Data message.
+// @inport _ Receives one input stream Data message.
 //
 // @outport res Sends a completion message that permits the next stream item.
 // @outport err Sends an error from that handler invocation.

--- a/std/streams/map.neva
+++ b/std/streams/map.neva
@@ -2,13 +2,21 @@ import {
 	@:sync
 }
 
-// IMapHandler is a dependency for Map.
+// IMapHandler transforms one Data message for Map.
+//
+// @inport data Receives each input stream Data message.
+//
+// @outport res Sends the replacement Data message.
 pub interface IMapHandler<T, Y>(T) (Y)
 
 // Map maps one stream onto another while preserving stream event order.
 //
 // It applies backpressure per Data item to guarantee Open/Data/Close sequencing.
 // Use ForEach instead when the handler performs side effects.
+//
+// @inport data Receives the stream whose Data messages are transformed.
+//
+// @outport res Sends an Open/Data/Close stream with transformed Data messages.
 pub def Map<T, Y>(data stream<T>) (res stream<Y>) {
 	turn sync.Turn<stream<T>>
 	event_switch Switch<stream<T>>

--- a/std/streams/map.neva
+++ b/std/streams/map.neva
@@ -4,9 +4,9 @@ import {
 
 // IMapHandler transforms one Data message for Map.
 //
-// @inport data Receives each input stream Data message.
+// @inport _ Receives each input stream Data message.
 //
-// @outport res Sends the replacement Data message.
+// @outport _ Sends the replacement Data message.
 pub interface IMapHandler<T, Y>(T) (Y)
 
 // Map maps one stream onto another while preserving stream event order.

--- a/std/streams/reduce.neva
+++ b/std/streams/reduce.neva
@@ -1,10 +1,20 @@
 // --- Reduce ---
 
-// IReducer is a dependency for Reduce.
+// IReducer combines the current reduction result with the next stream message.
+//
+// @inport left Receives the current accumulated result.
+// @inport right Receives the next input stream Data message.
+//
+// @outport res Sends the next accumulated result.
 pub interface IReducer<T, Y>(left T, right T) (res Y)
 
-// Reduce applies a reduction component to a stream of messages, accumulating the result.
-// It takes an initial value and a stream of data, and produces a single result.
+// Reduce accumulates a stream with a reduction handler and initial result.
+// It emits only after the input stream closes.
+//
+// @inport data Receives the stream whose Data messages are reduced.
+// @inport init Receives the initial accumulated result.
+//
+// @outport res Sends the final accumulated result after the stream closes.
 pub def Reduce<T, Y>(data stream<T>, init Y) (res Y) {
 	del_open Del
 	reducer IReducer<T, Y>

--- a/std/streams/streams.neva
+++ b/std/streams/streams.neva
@@ -1,5 +1,6 @@
 // --- Sources ---
 
+// Enumerated carries a stream item with its zero-based position.
 pub type Enumerated<T> struct {
 	idx int
 	item T
@@ -7,10 +8,18 @@ pub type Enumerated<T> struct {
 
 // FromArray iterates over all array-inport's slots in order
 // and produces a stream of messages.
+//
+// @inport port Receives messages from each array slot in slot order.
+//
+// @outport res Sends an Open/Data/Close stream containing those messages.
 #extern(array_port_to_stream)
 pub def FromArray<T>([port] T) (res stream<T>)
 
 // FromList creates a stream from a list by sending each element as a stream item.
+//
+// @inport data Receives the list converted into a stream.
+//
+// @outport res Sends an Open/Data/Close stream of the list items in order.
 #extern(list_to_stream)
 pub def FromList<T>(data list<T>) (res stream<T>)
 
@@ -18,6 +27,10 @@ pub def FromList<T>(data list<T>) (res stream<T>)
 // Each stream item is a single-code-point string (Go rune semantics).
 // This intentionally does not iterate bytes: multibyte UTF-8 characters
 // must remain whole stream elements.
+//
+// @inport data Receives the text converted into Unicode-code-point messages.
+//
+// @outport res Sends an Open/Data/Close stream of one-code-point strings.
 #extern(string_to_stream)
 pub def FromString(data string) (res stream<string>)
 // Just creates a stream that contains exactly one Data item.
@@ -25,7 +38,7 @@ pub def FromString(data string) (res stream<string>)
 // This is useful when an API expects a stream but the producer has one value,
 // for example when adapting scalar data to a stream combinator.
 //
-// @inport data Value to emit as the only Data item.
+// @inport data Receives the message emitted as the only Data item.
 //
 // @outport res Stream that emits Open, Data(data), and Close.
 #extern(stream_just)
@@ -33,22 +46,38 @@ pub def Just<T>(data T) (res stream<T>)
 
 // FromDict creates a stream of dictionary entries.
 // Dictionary iteration order is not guaranteed.
+//
+// @inport data Receives the dictionary converted into entry messages.
+//
+// @outport res Sends an Open/Data/Close stream of dictionary entries.
 #extern(dict_to_stream)
 pub def FromDict<T>(data dict<T>) (res stream<DictEntry<T>>)
 
-// Range sends stream of integers starting and ending with given `from` and `to`.
-// It supports negative ranges e.g. `-3, 0`. Integers are decremented in that case.
-// It emits stream only after both inports receive messages.
+// Range sends integers from `from` toward `to` as a stream.
+// It supports negative ranges and starts only after both bounds arrive.
+//
+// @inport from Receives the inclusive range bound where the stream starts.
+// @inport to Receives the exclusive range bound where the stream ends.
+//
+// @outport res Sends an Open/Data/Close stream of the range integers.
 #extern(stream_int_range)
 pub def Range(from int, to int) (res stream<int>)
 
 // Enumerate attaches a 0-based index to each Data item in a stream.
+//
+// @inport data Receives the stream whose Data messages are indexed.
+//
+// @outport res Sends the same stream protocol with each Data item enumerated.
 #extern(stream_enumerate)
 pub def Enumerate<T>(data stream<T>) (res stream<Enumerated<T>>)
 
 // --- Synchronization ---
 
-// Wait blocks until stream closes, then sends a signal.
+// Wait forwards a signal after an input stream closes.
+//
+// @inport data Receives the stream observed until its Close message.
+//
+// @outport sig Sends a completion signal after Close arrives.
 pub def Wait(data stream<any>) (sig any) {
 	switch Switch<stream<any>>
 	---
@@ -61,30 +90,41 @@ pub def Wait(data stream<any>) (sig any) {
 
 // --- Combinators ---
 
-// Produces a stream of tuples of the form (left, right)
-// where left is from the left stream and right is from the right stream.
-// Stops when either stream is exhausted.
+// Zip pairs corresponding items from two streams until either stream closes.
+//
+// @inport left Receives the stream providing the first member of each pair.
+// @inport right Receives the stream providing the second member of each pair.
+//
+// @outport res Sends an Open/Data/Close stream of paired items.
 #extern(stream_zip)
 pub def Zip<T, R>(left stream<T>, right stream<R>) (res stream<ZipResult<T, R>>)
 
+// ZipResult carries one pair emitted by Zip.
 pub type ZipResult<T, R> struct {
-    left T
-    right R
+	left T
+	right R
 }
 
-// Produces a stream of lists where each list contains items from the
-// corresponding positions of the input streams. Stops when any stream is
-// exhausted.
+// ZipMany groups corresponding input items until one stream closes.
+//
+// @inport data Receives the streams whose corresponding items are grouped.
+//
+// @outport res Sends an Open/Data/Close stream of grouped item lists.
 #extern(stream_zip_many)
 pub def ZipMany<T>([data] stream<T>) (res stream<list<T>>)
 
-// Product waits for each input stream to complete,
-// then outputs stream of every combination of elements from the first stream with
-// elements from the second.
+// Product collects two streams, then emits every pair of their items.
+// It waits for both streams to close and may use unbounded memory.
+//
+// @inport first Receives the first stream used to form product pairs.
+// @inport second Receives the second stream used to form product pairs.
+//
+// @outport res Sends an Open/Data/Close stream of every product pair.
 #extern(stream_product)
 pub def Product<T, Y>(first stream<T>, second stream<Y>) (res stream<ProductResult<T, Y>>)
 
+// ProductResult carries one pair emitted by Product.
 pub type ProductResult<T, Y> struct {
-    first T
-    second Y
+	first T
+	second Y
 }

--- a/std/strings/strings.neva
+++ b/std/strings/strings.neva
@@ -1,16 +1,51 @@
+// Join combines list elements with a separator.
+//
+// @inport data Receives the list of strings joined into one message.
+// @inport sep Receives the separator inserted between adjacent elements.
+//
+// @outport res Sends the joined string.
 #extern(strings_join_list)
 pub def Join(data list<string>, sep string) (res string)
+
+// Join combines stream items with a separator after the stream closes.
+// It waits for the full stream and may use unbounded memory.
+//
+// @inport data Receives the stream of strings collected for joining.
+// @inport sep Receives the separator inserted between adjacent stream items.
+//
+// @outport res Sends the joined string after the input stream closes.
 #extern(strings_join_stream)
 pub def Join(data stream<string>, sep string) (res string)
 
+// Split separates text around each occurrence of a delimiter.
+//
+// @inport data Receives the text to split.
+// @inport delim Receives the delimiter used to find boundaries.
+//
+// @outport res Sends the resulting list of substrings.
 #extern(strings_split)
 pub def Split(data string, delim string) (res list<string>)
 
+// ToUpper converts text to uppercase using Unicode case mapping.
+//
+// @inport data Receives the text to convert.
+//
+// @outport res Sends the uppercased text.
 #extern(strings_to_upper)
 pub def ToUpper(data string) (res string)
 
+// ToLower converts text to lowercase using Unicode case mapping.
+//
+// @inport data Receives the text to convert.
+//
+// @outport res Sends the lowercased text.
 #extern(strings_to_lower)
 pub def ToLower(data string) (res string)
 
+// FromBytes decodes bytes as UTF-8 text.
+//
+// @inport data Receives the bytes to decode.
+//
+// @outport res Sends the decoded string.
 #extern(strings_from_bytes)
 pub def FromBytes(data bytes) (res string)

--- a/std/sync/sync.neva
+++ b/std/sync/sync.neva
@@ -1,21 +1,15 @@
-// WaitGroup implements a "wait group" which outputs a signal after the count decreases to 0 via sending to :sig.
+// WaitGroup signals after its counter reaches zero.
+// It waits for an initial count before treating `sig` messages as decrements.
 //
-// Send to :count to set the initial counter.
-// Send to :sig to decrement the counter.
-// WaitGroup will not output a signal until it received at least :count.
+// @inport count Receives the initial number of completion signals required.
+// @inport sig Receives each signal that decrements the current count.
 //
-// Example:
-//  sync.WaitGroup
-// ---
-//  :start -> 2 -> wg:count
-//  task1 -> true -> wg:sig
-//  task2 -> true -> wg:sig
-//  wg -> :stop  // Signals after both tasks are done.
+// @outport sig Sends one signal when the counter reaches zero.
 //
-// Example:
-//  sync.Wg
-// ---
-//  wg -> :stop  // Blocks forever.
+// @example :start -> 2 -> wg:count
+// @example task1 -> true -> wg:sig
+// @example task2 -> true -> wg:sig
+// @example wg -> :stop
 #extern(wait_group)
 pub def WaitGroup(count int, sig any) (sig any)
 
@@ -57,5 +51,10 @@ pub def Sync<T>(data T) (res T, err error) {
 	lock -> [turn:done, :res]
 }
 
-// ISyncHandler completes one sequential unit of work.
+// ISyncHandler completes one sequential unit of work for Sync.
+//
+// @inport data Receives the message handled by one unit of work.
+//
+// @outport res Sends a completion message after the work succeeds.
+// @outport err Sends the error that ends the unit of work.
 pub interface ISyncHandler<T>(data T) (res any, err error)

--- a/std/time/time.neva
+++ b/std/time/time.neva
@@ -8,16 +8,22 @@ pub const second      Duration = 1000000000
 pub const minute      Duration = 60000000000
 pub const hour        Duration = 3600000000000
 
-// After blocks the flow for (at least) provided duration.
-// When enough time has passed, it sends a signal to its output port.
-// If you want to delay a message, use Delay instead.
+// After waits for at least the requested duration before signalling completion.
+// Use Delay when a message must continue after the wait.
+//
+// @inport dur Receives the duration that starts one timer.
+//
+// @outport sig Sends a completion signal after that timer expires.
 #extern(time_after)
 pub def After(dur Duration) (sig any)
 
-// Delay waits for both dur and data messages.
-// As soon as they both arrive it starts waiting
-// for (at least) provided duration.
-// When enough time has passed, it sends a data to its output port.
-// If all you need is just block the flow, use Sleep instead.
+// Delay waits for a duration and a message, then forwards that message later.
+// The timer starts only after both ports receive messages. Use After when only
+// a completion signal is needed.
+//
+// @inport dur Receives the duration for one delayed message.
+// @inport data Receives the message held until the duration expires.
+//
+// @outport res Sends the held message after the timer expires.
 #extern(time_delay)
 pub def Delay<T>(dur Duration, data T) (res T)


### PR DESCRIPTION
## Summary

- Define port-oriented structured comments in the style guide.
- Document public standard-library entities across every stdlib package, including complete port sections where tags apply.
- Normalize nearby vertical spacing without changing Neva declarations, graphs, types, or runtime code.

Refs #973

## Validation

- `go test ./internal/compiler/...`
- `go test -v ./e2e/... ./examples/...`
- `git diff --check`
- `lefthook run pre-commit`
- `neva doc streams Just`, `neva doc sync WaitGroup`, and `neva doc os Getenv`

## CI note

`gofix-check`, `golangci`, `govulncheck`, and installer checks pass. The `unit_tests` failure is reproduced unchanged on `origin/main`: `pkg/indexer` and `pkg/view` workspace scans return `found == false`; consequently the workflow skips `e2e_tests`. This PR does not alter indexer, view, or runtime behavior.