### PR TITLE
Add nevafmt parser foundation

### DIFF
--- a/docs/user/qna.md
+++ b/docs/user/qna.md
@@ -64,30 +64,6 @@ In practice, this means:
 - Human-readable scalar-to-string formatting should also live in `strconv` (Go style),
   for example `strconv.Itoa`/`FormatFloat`/`FormatBool`.
 
-## Why will Neva ship `neva fmt` instead of requiring a separate formatter?
-
-Formatting source code is a first-party language-tooling contract, not a
-third-party convention. Neva will ship one canonical formatter as `neva fmt`
-with the main Neva release, so a developer, CI system, and editor use the same
-formatter version as the parser that accepts the source.
-
-This follows the Go model: formatting should work immediately after installing
-the language toolchain, should require no project-specific style configuration,
-and should remove whitespace-only review discussion. The formatter will parse
-one source file at a time; it will not require a successful build, resolved
-dependencies, or type checking.
-
-`neva tool` remains useful for separately installed developer tools such as a
-language server or experimental integrations. It is not the primary entry
-point for canonical source formatting, because an independently installed
-formatter could be incompatible with the installed Neva language version.
-
-The formatter intentionally has a narrow job: preserve program meaning and
-comments while rendering canonical layout. Import policy, naming, complexity
-warnings, and semantic rewrites belong to `neva lint`, editor code actions, or
-future refactoring commands rather than silently changing source under the
-name of formatting.
-
 ## What determines which entities are in the builtin package?
 
 Builtin is Neva's implicit prelude. Every file can reference builtin entities
@@ -343,3 +319,10 @@ Operators should follow same pattern for simplicity of desugarer and usage by us
 ## Why does Neva have overloading, and why can’t users define it?
 
 Neva uses overloading internally to keep the standard library conceptually small without forcing users to deal with tagged unions, explicit type arguments, or name explosions for every concrete type. This improves day-to-day DX in an operator-less, component-only language. However, exposing overloading to users would introduce mental-model complexity: it makes APIs harder to reason about as systems grow. By keeping overloading limited to the `builtin` package, Neva captures the ergonomic benefits where they matter most while preserving a simple, predictable model for user code.
+
+## Why will Neva ship `neva fmt` instead of requiring a separate formatter?
+
+`neva fmt` is part of the language toolchain, so developers, editors, and CI
+use the formatter version that matches the parser. It needs no project config
+or successful build. Separately installed tools belong under `neva tool`; lint
+and refactorings remain separate from formatting.

--- a/docs/user/qna.md
+++ b/docs/user/qna.md
@@ -64,6 +64,30 @@ In practice, this means:
 - Human-readable scalar-to-string formatting should also live in `strconv` (Go style),
   for example `strconv.Itoa`/`FormatFloat`/`FormatBool`.
 
+## Why will Neva ship `neva fmt` instead of requiring a separate formatter?
+
+Formatting source code is a first-party language-tooling contract, not a
+third-party convention. Neva will ship one canonical formatter as `neva fmt`
+with the main Neva release, so a developer, CI system, and editor use the same
+formatter version as the parser that accepts the source.
+
+This follows the Go model: formatting should work immediately after installing
+the language toolchain, should require no project-specific style configuration,
+and should remove whitespace-only review discussion. The formatter will parse
+one source file at a time; it will not require a successful build, resolved
+dependencies, or type checking.
+
+`neva tool` remains useful for separately installed developer tools such as a
+language server or experimental integrations. It is not the primary entry
+point for canonical source formatting, because an independently installed
+formatter could be incompatible with the installed Neva language version.
+
+The formatter intentionally has a narrow job: preserve program meaning and
+comments while rendering canonical layout. Import policy, naming, complexity
+warnings, and semantic rewrites belong to `neva lint`, editor code actions, or
+future refactoring commands rather than silently changing source under the
+name of formatting.
+
 ## What determines which entities are in the builtin package?
 
 Builtin is Neva's implicit prelude. Every file can reference builtin entities

--- a/internal/compiler/parser/parser.go
+++ b/internal/compiler/parser/parser.go
@@ -10,7 +10,6 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 
 	"github.com/nevalang/neva/internal/compiler"
-	generated "github.com/nevalang/neva/internal/compiler/parser/generated"
 	src "github.com/nevalang/neva/pkg/ast"
 	"github.com/nevalang/neva/pkg/core"
 )
@@ -89,18 +88,10 @@ func (p Parser) parseFile(
 	fileName string,
 	content []byte,
 ) (src.File, *compiler.Error) {
-	input := antlr.NewInputStream(string(content))
-	lexer := generated.NewnevaLexer(input)
-	lexerErrors := &CustomErrorListener{}
-	lexer.RemoveErrorListeners()
-	lexer.AddErrorListener(lexerErrors)
-	tokenStream := antlr.NewCommonTokenStream(lexer, 0)
-
-	parserErrors := &CustomErrorListener{}
-	prsr := generated.NewnevaParser(tokenStream)
-	prsr.RemoveErrorListeners()
-	prsr.AddErrorListener(parserErrors)
-	prsr.BuildParseTrees = true
+	parsed, err := ParseSource(content)
+	if err != nil {
+		return src.File{}, err
+	}
 
 	listener := &treeShapeListener{
 		loc: core.Location{
@@ -111,16 +102,8 @@ func (p Parser) parseFile(
 		sourceLines: strings.Split(string(content), "\n"),
 	}
 
-	if err := walkTree(listener, prsr.Prog()); err != nil {
+	if err := walkTree(listener, parsed.Tree); err != nil {
 		return src.File{}, err
-	}
-
-	if len(lexerErrors.Errors) > 0 {
-		return src.File{}, lexerErrors.Errors[0]
-	}
-
-	if len(parserErrors.Errors) > 0 {
-		return src.File{}, parserErrors.Errors[0]
 	}
 
 	return listener.state, nil

--- a/internal/compiler/parser/syntax.go
+++ b/internal/compiler/parser/syntax.go
@@ -1,0 +1,54 @@
+package parser
+
+import (
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/nevalang/neva/internal/compiler"
+	generated "github.com/nevalang/neva/internal/compiler/parser/generated"
+)
+
+// ParsedSource is the syntax-preserving result of parsing one Neva source file.
+//
+// Unlike the compiler AST, it retains the original source and every parser-visible
+// token, including comments and newlines. Source tooling such as the formatter
+// must use this representation rather than the semantic AST, whose maps do not
+// retain source order or complete trivia.
+type ParsedSource struct {
+	Tree   generated.IProgContext
+	Source []byte
+	Tokens []antlr.Token
+}
+
+// ParseSource parses source without building the compiler's semantic AST.
+// It returns the complete parser-visible token stream so source tooling can
+// preserve comments and newlines while rendering the parsed syntax.
+func ParseSource(source []byte) (ParsedSource, *compiler.Error) {
+	input := antlr.NewInputStream(string(source))
+	lexer := generated.NewnevaLexer(input)
+	lexerErrors := &CustomErrorListener{}
+	lexer.RemoveErrorListeners()
+	lexer.AddErrorListener(lexerErrors)
+
+	tokenStream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	parserErrors := &CustomErrorListener{}
+	prsr := generated.NewnevaParser(tokenStream)
+	prsr.RemoveErrorListeners()
+	prsr.AddErrorListener(parserErrors)
+	prsr.BuildParseTrees = true
+
+	tree := prsr.Prog()
+	tokenStream.Fill()
+
+	if len(lexerErrors.Errors) > 0 {
+		return ParsedSource{}, lexerErrors.Errors[0]
+	}
+	if len(parserErrors.Errors) > 0 {
+		return ParsedSource{}, parserErrors.Errors[0]
+	}
+
+	return ParsedSource{
+		Source: source,
+		Tokens: tokenStream.GetAllTokens(),
+		Tree:   tree,
+	}, nil
+}

--- a/internal/compiler/parser/syntax_test.go
+++ b/internal/compiler/parser/syntax_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseSourcePreservesSourceTokensAndTree(t *testing.T) {
 	t.Parallel()
 
-	source := []byte("// Greets the caller\n" +
+	source := []byte("// Passes start through.\n" +
 		"def Main(start any) (stop any) {\n" +
 		"\t:start -> :stop\n" +
 		"}\n")

--- a/internal/compiler/parser/syntax_test.go
+++ b/internal/compiler/parser/syntax_test.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSourcePreservesSourceTokensAndTree(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("// Greets the caller\n" +
+		"def Main(start any) (stop any) {\n" +
+		"\t:start -> :stop\n" +
+		"}\n")
+
+	parsed, err := ParseSource(source)
+	require.Nil(t, err)
+	require.Equal(t, source, parsed.Source)
+	require.NotNil(t, parsed.Tree)
+	require.NotEmpty(t, parsed.Tokens)
+
+	var comments, newlines int
+	for _, token := range parsed.Tokens {
+		switch {
+		case strings.HasPrefix(token.GetText(), "//"):
+			comments++
+		case token.GetText() == "\n":
+			newlines++
+		}
+	}
+	require.Equal(t, 1, comments)
+	require.Equal(t, 4, newlines)
+}
+
+func TestParseSourceReturnsSyntaxError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseSource([]byte("def Main(start any) (stop any) {\n"))
+	require.Error(t, err)
+	require.Equal(t, 2, err.Meta.Start.Line)
+}


### PR DESCRIPTION
## Summary

Starts the implementation of the canonical `neva fmt` RFC (#1171).

- adds a syntax-preserving `parser.ParseSource` API with original source, the complete ANTLR token stream, and parse tree;
- makes the existing compiler AST parser reuse that parsing setup;
- documents why formatting ships as first-party `neva fmt`, rather than an independently installed tool;
- adds coverage for comment/newline token retention and syntax-error reporting.

## Design boundary

This PR deliberately does **not** expose a partial `neva fmt` command or a whitespace heuristic. The next slice will define golden fixtures and a pure renderer on this API, so formatting cannot silently damage valid source layout or comments.

## Validation

- `go test ./internal/compiler/...`
- `go test ./internal/cli`
- `git diff --check`

The repository-wide pre-push lint currently reports 25 pre-existing findings in `internal/compiler/analyzer` and `internal/compiler/typesystem`, outside this PR's diff. Unit tests, gofix diff check, and vulncheck passed.