### PR TITLE
docs: add papercut workflow

### DIFF
--- a/.codex/papercuts.md
+++ b/.codex/papercuts.md
@@ -1,0 +1,26 @@
+# Papercuts
+
+Private maintainer journal for small repository and engineering-harness
+frictions encountered by LLMs. Entries are generated with the repository-local
+skill that owns this file.
+
+---
+
+<!-- Add papercuts below this line. Put new entries first. -->
+
+## 2026-08-02 12:05 +07 — Codex
+
+Validating this documentation change with `pre-commit run --files ...` ->
+`InvalidConfigError: .pre-commit-config.yaml is not a file`, despite the
+engineering guide saying the stop hook runs pre-commit after a changed turn.
+Used `git diff --check` for this documentation-only change. Likely fix: make
+the hook detect a repository configuration before invoking pre-commit, or
+document the intended configuration location.
+
+## 2026-08-02 12:08 +07 — Codex
+
+Pushing this documentation-only branch -> the pre-push `make lint` gate failed
+on lint violations unchanged from `origin/main`; it also reported files from a
+sibling worktree. The same gate's unit tests and vulnerability scan passed.
+Likely fix: restore a clean lint baseline and isolate the lint scan to the
+current worktree.

--- a/.codex/skills/papercut/SKILL.md
+++ b/.codex/skills/papercut/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: "papercut"
+description: "Capture or triage small Neva repository and engineering-harness frictions without derailing feature work."
+---
+
+# Papercut
+
+Use this skill when a person or agent encounters minor friction while doing
+other Neva work: a flaky command, stale cache, misleading error, obsolete
+script, or documentation that contradicts observed behavior.
+
+The journal is [`.codex/papercuts.md`](../../papercuts.md).
+It is not an issue tracker. Product, language, compiler, and runtime defects
+belong in their owning GitHub issue or change; already-tracked work stays there.
+
+## Capture
+
+1. Keep working on the original task unless the friction blocks it.
+2. Add one entry directly below the journal marker, newest first:
+
+   ```text
+   ## YYYY-MM-DD HH:MM TZ — author or model
+
+   What I was doing -> what got in the way. Include the relevant command or
+   error, workaround, and likely cause or fix when known.
+   ```
+
+3. Record only evidence already observed. Never put credentials, access tokens,
+   or private data in an entry.
+
+## Triage
+
+1. Read the full journal and group duplicate symptoms.
+2. Reproduce or otherwise verify each candidate before assigning a cause.
+3. Convert a meaningful item into the smallest durable outcome: a test,
+   automation, documentation update, or GitHub issue.
+4. Link that outcome in the pull request or issue, then remove the triaged
+   entry from the journal. Leave unverified entries intact.
+
+Do not silently broaden the current task to implement a separate fix. Ask for
+direction when the remediation is material and not already in scope.


### PR DESCRIPTION
## Summary
- add a developer journal for small repository and harness friction
- add the repository-local `papercut` capture/triage skill
- record two observed harness frictions as its initial entries

## Validation
- `git diff --check`
- `lefthook run pre-commit`
- pre-push `make test-unit` and `make vulncheck` passed
- pre-push `make lint` failed on violations unchanged from `origin/main`, including reports from a sibling worktree; GitHub CI is the readiness gate

The existing untracked `.codex/plans/encoding_json_v1.md` was not included.