### PR TITLE
fix: receive runtime inputs concurrently

### DIFF
--- a/internal/runtime/funcs/match.go
+++ b/internal/runtime/funcs/match.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/nevalang/neva/internal/runtime"
 	"github.com/nevalang/neva/internal/runtime/messages"
@@ -48,30 +49,35 @@ func (matchSelector) Create(io runtime.IO, _ messages.Msg) (func(ctx context.Con
 
 	return func(ctx context.Context) {
 		for {
-			//nolint:varnamelen // TODO(strict-lint phase 1): temporary suppression; remove after strict cleanup.
-			dataMsg, ok := dataIn.Receive(ctx)
-			if !ok {
-				return
-			}
-
+			var dataMsg, elseInMsg runtime.OrderedMsg
+			var dataOK, ifOK, thenOK, elseOK bool
 			ifMsgs := make([]runtime.OrderedMsg, ifIn.Len())
-			if !ifIn.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
-				ifMsgs[idx] = ordered
-				return true
-			}) {
-				return
-			}
-
 			thenMsgs := make([]runtime.OrderedMsg, thenOut.Len())
-			if !thenOut.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
-				thenMsgs[idx] = ordered
-				return true
-			}) {
-				return
-			}
 
-			elseInMsg, ok := elseIn.Receive(ctx)
-			if !ok {
+			// All inputs select one result. Receive them concurrently so their
+			// producers may send in any order.
+			var group sync.WaitGroup
+			group.Go(func() {
+				dataMsg, dataOK = dataIn.Receive(ctx)
+			})
+			group.Go(func() {
+				ifOK = ifIn.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
+					ifMsgs[idx] = ordered
+					return true
+				})
+			})
+			group.Go(func() {
+				thenOK = thenOut.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
+					thenMsgs[idx] = ordered
+					return true
+				})
+			})
+			group.Go(func() {
+				elseInMsg, elseOK = elseIn.Receive(ctx)
+			})
+			group.Wait()
+
+			if !dataOK || !ifOK || !thenOK || !elseOK {
 				return
 			}
 

--- a/internal/runtime/funcs/match_test.go
+++ b/internal/runtime/funcs/match_test.go
@@ -65,3 +65,73 @@ func TestMatchSendsDataIfThenCauses(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestMatchReceivesInputsConcurrently(t *testing.T) {
+	tracer := runtime.NewTracer()
+	interceptor := runtime.NoEffectInterceptor{}
+	dataIn := make(chan runtime.OrderedMsg)
+	ifInput := make(chan runtime.OrderedMsg)
+	thenInput := make(chan runtime.OrderedMsg)
+	elseIn := make(chan runtime.OrderedMsg)
+	resOut := make(chan runtime.OrderedMsg, 1)
+
+	io := runtime.IO{
+		In: runtime.NewInports(map[string]runtime.Inport{
+			"data": runtime.NewInport(nil, runtime.NewSingleInport(tracer, dataIn, runtime.PortAddr{Path: "test/in", Port: "data"}, interceptor)),
+			"if":   runtime.NewInport(runtime.NewArrayInport(tracer, []<-chan runtime.OrderedMsg{ifInput}, runtime.PortAddr{Path: "test/in", Port: "if"}, interceptor), nil),
+			"then": runtime.NewInport(runtime.NewArrayInport(tracer, []<-chan runtime.OrderedMsg{thenInput}, runtime.PortAddr{Path: "test/in", Port: "then"}, interceptor), nil),
+			"else": runtime.NewInport(nil, runtime.NewSingleInport(tracer, elseIn, runtime.PortAddr{Path: "test/in", Port: "else"}, interceptor)),
+		}),
+		Out: runtime.NewOutports(map[string]runtime.Outport{
+			"res": runtime.NewOutport(runtime.NewSingleOutport(tracer, runtime.PortAddr{Path: "test/out", Port: "res"}, interceptor, resOut), nil),
+		}),
+	}
+
+	handler, err := (matchSelector{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	cancel, handlerDone := runHandler(handler)
+	t.Cleanup(func() {
+		cancel()
+		<-handlerDone
+	})
+
+	stopSender := make(chan struct{})
+	t.Cleanup(func() { close(stopSender) })
+	sent := make(chan struct{})
+	go func() {
+		for _, input := range []struct {
+			ch  chan runtime.OrderedMsg
+			msg messages.Msg
+		}{
+			{ifInput, messages.NewStringMsg("key")},
+			{thenInput, messages.NewStringMsg("match")},
+			{elseIn, messages.NewStringMsg("fallback")},
+			{dataIn, messages.NewStringMsg("key")},
+		} {
+			select {
+			case input.ch <- runtime.OrderedMsg{Msg: input.msg}:
+			case <-stopSender:
+				return
+			}
+		}
+		close(sent)
+	}()
+
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("match blocked before receiving all independent inputs")
+	}
+
+	select {
+	case out := <-resOut:
+		if !messages.Equal(out.Msg, messages.NewStringMsg("match")) {
+			t.Fatalf("payload = %v, want match", out)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting result")
+	}
+}

--- a/internal/runtime/funcs/select.go
+++ b/internal/runtime/funcs/select.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/nevalang/neva/internal/runtime"
 	"github.com/nevalang/neva/internal/runtime/messages"
@@ -36,16 +37,25 @@ func (selector) Create(io runtime.IO, _ messages.Msg) (func(ctx context.Context)
 
 	return func(ctx context.Context) {
 		for {
-			ifMsg, ok := ifArrIn.Select(ctx)
-			if !ok {
-				return
-			}
-
+			var ifMsg runtime.SelectedMsg
+			var ifOK, thenOK bool
 			then := make([]messages.Msg, thenArrIn.Len())
-			if !thenArrIn.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
-				then[idx] = ordered.Msg
-				return true
-			}) {
+
+			// The trigger and candidate values form one selection operation.
+			// Receive them concurrently so either side may arrive first.
+			var group sync.WaitGroup
+			group.Go(func() {
+				ifMsg, ifOK = ifArrIn.Select(ctx)
+			})
+			group.Go(func() {
+				thenOK = thenArrIn.ReceiveAll(ctx, func(idx int, ordered runtime.OrderedMsg) bool {
+					then[idx] = ordered.Msg
+					return true
+				})
+			})
+			group.Wait()
+
+			if !ifOK || !thenOK {
 				return
 			}
 

--- a/internal/runtime/funcs/select_test.go
+++ b/internal/runtime/funcs/select_test.go
@@ -57,3 +57,67 @@ func TestSelectorSendsIfCause(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestSelectorReceivesInputsConcurrently(t *testing.T) {
+	tracer := runtime.NewTracer()
+	interceptor := runtime.NoEffectInterceptor{}
+	ifInput := make(chan runtime.OrderedMsg)
+	thenInput := make(chan runtime.OrderedMsg)
+	resOut := make(chan runtime.OrderedMsg, 1)
+
+	io := runtime.IO{
+		In: runtime.NewInports(map[string]runtime.Inport{
+			"if":   runtime.NewInport(runtime.NewArrayInport(tracer, []<-chan runtime.OrderedMsg{ifInput}, runtime.PortAddr{Path: "test/in", Port: "if"}, interceptor), nil),
+			"then": runtime.NewInport(runtime.NewArrayInport(tracer, []<-chan runtime.OrderedMsg{thenInput}, runtime.PortAddr{Path: "test/in", Port: "then"}, interceptor), nil),
+		}),
+		Out: runtime.NewOutports(map[string]runtime.Outport{
+			"res": runtime.NewOutport(runtime.NewSingleOutport(tracer, runtime.PortAddr{Path: "test/out", Port: "res"}, interceptor, resOut), nil),
+		}),
+	}
+
+	handler, err := (selector{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	cancel, handlerDone := runHandler(handler)
+	t.Cleanup(func() {
+		cancel()
+		<-handlerDone
+	})
+
+	stopSender := make(chan struct{})
+	t.Cleanup(func() { close(stopSender) })
+	sent := make(chan struct{})
+	go func() {
+		for _, input := range []struct {
+			ch  chan runtime.OrderedMsg
+			msg messages.Msg
+		}{
+			{thenInput, messages.NewStringMsg("selected")},
+			{ifInput, messages.NewBoolMsg(true)},
+		} {
+			select {
+			case input.ch <- runtime.OrderedMsg{Msg: input.msg}:
+			case <-stopSender:
+				return
+			}
+		}
+		close(sent)
+	}()
+
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("select blocked before receiving all independent inputs")
+	}
+
+	select {
+	case out := <-resOut:
+		if !messages.Equal(out.Msg, messages.NewStringMsg("selected")) {
+			t.Fatalf("payload = %v, want selected", out)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting result")
+	}
+}

--- a/internal/runtime/funcs/turn.go
+++ b/internal/runtime/funcs/turn.go
@@ -29,6 +29,22 @@ func (turn) Create(runtimeIO runtime.IO, _ messages.Msg) (func(ctx context.Conte
 	return newTurnHandler(doneIn, dataIn, resOut), nil
 }
 
+// receiveTurnInputs receives the first data message directly and each following data/done pair concurrently.
+func receiveTurnInputs(
+	ctx context.Context,
+	first bool,
+	dataIn, doneIn runtime.SingleInport,
+) (runtime.OrderedMsg, runtime.OrderedMsg, bool) {
+	if first {
+		data, received := dataIn.Receive(ctx)
+		return data, runtime.OrderedMsg{}, received
+	}
+
+	// The previous acknowledgement and the next data message form one operation.
+	// Receive both concurrently so either sender can arrive first.
+	return receive2(ctx, dataIn, doneIn)
+}
+
 // newTurnHandler releases the first message, then pairs each following message with done.
 func newTurnHandler(
 	doneIn, dataIn runtime.SingleInport,
@@ -37,20 +53,19 @@ func newTurnHandler(
 	return func(ctx context.Context) {
 		first := true
 		for {
-			if !first {
-				if _, received := doneIn.Receive(ctx); !received {
-					return
-				}
-			}
-
-			data, received := dataIn.Receive(ctx)
+			data, done, received := receiveTurnInputs(ctx, first, dataIn, doneIn)
 			if !received {
 				return
 			}
 
-			if !resOut.Send(ctx, data) {
+			if first {
+				if !resOut.Send(ctx, data) {
+					return
+				}
+			} else if !resOut.Send(ctx, data, data, done) {
 				return
 			}
+
 			first = false
 		}
 	}

--- a/internal/runtime/funcs/turn_test.go
+++ b/internal/runtime/funcs/turn_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nevalang/neva/internal/runtime/messages"
 )
 
-func TestTurnWaitsForDoneBeforeReceivingNextData(t *testing.T) {
+func TestTurnWaitsForDoneBeforeReleasingNextData(t *testing.T) {
 	io, inChans, outChans := newIO([]string{"data", "done"}, []string{"res"})
 	handler, err := (turn{}).Create(io, nil)
 	if err != nil {
@@ -33,16 +33,62 @@ func TestTurnWaitsForDoneBeforeReceivingNextData(t *testing.T) {
 
 	select {
 	case <-secondSent:
-		t.Fatal("turn received the second data before done")
+	case <-time.After(time.Second):
+		t.Fatal("turn did not receive the second data")
+	}
+
+	select {
+	case output := <-outChans["res"]:
+		t.Fatalf("turn released %v before done", output)
 	case <-time.After(50 * time.Millisecond):
 	}
 
 	sendInOrder(t, inChans, []string{"done"}, map[string]messages.Msg{"done": messages.NewBoolMsg(true)})
 
-	select {
-	case <-secondSent:
-	case <-time.After(time.Second):
-		t.Fatal("turn did not receive the second data after done")
-	}
 	assertOutputEquals(t, outChans, "res", messages.NewIntMsg(2), []string{"done", "data"})
+}
+
+func TestTurnReceivesDoneAndNextDataConcurrently(t *testing.T) {
+	io, inChans, outChans := newIO([]string{"data", "done"}, []string{"res"})
+	handler, err := (turn{}).Create(io, nil)
+	if err != nil {
+		t.Fatalf("create turn handler: %v", err)
+	}
+
+	cancel, handlerDone := runHandler(handler)
+	t.Cleanup(func() {
+		cancel()
+		<-handlerDone
+	})
+
+	first := messages.NewIntMsg(1)
+	sendInOrder(t, inChans, []string{"data"}, map[string]messages.Msg{"data": first})
+	assertOutputEquals(t, outChans, "res", first, []string{"data"})
+
+	stopSender := make(chan struct{})
+	t.Cleanup(func() { close(stopSender) })
+	nextSent := make(chan struct{})
+	go func() {
+		select {
+		case inChans["data"] <- runtime.OrderedMsg{Msg: messages.NewIntMsg(2)}:
+		case <-stopSender:
+			return
+		}
+
+		select {
+		case inChans["done"] <- runtime.OrderedMsg{Msg: messages.NewBoolMsg(true)}:
+		case <-stopSender:
+			return
+		}
+
+		close(nextSent)
+	}()
+
+	select {
+	case <-nextSent:
+	case <-time.After(time.Second):
+		t.Fatal("turn blocked data before receiving done")
+	}
+
+	assertOutputEquals(t, outChans, "res", messages.NewIntMsg(2), []string{"data", "done"})
 }


### PR DESCRIPTION
## Summary
- receive independent Turn data and done inputs concurrently after the first event
- preserve both inputs as causes for subsequent Turn output
- fix the same sequential-receive deadlock risk in Match and Select
- add regression tests for sender-order independence

## Validation
- go test ./internal/runtime/funcs -count=1
- go test ./e2e/stream_split -count=10
- go test ./e2e/slow_iteration_with_map ./e2e/slow_iteration_with_for ./e2e/sync -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./internal/runtime/funcs