### PR TITLE
Validate formatter against source corpus

### DIFF
--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -61,6 +61,7 @@ func renderTokens(tokens []antlr.Token, layout *layoutAnnotations) []byte {
 		if importBlock, ok := layout.importBlocks[index]; ok {
 			flush()
 			output.Write(renderImportBlock(importBlock, layout))
+			previousWasNewline = false
 			index = importBlock.end
 			continue
 		}
@@ -72,7 +73,7 @@ func renderTokens(tokens []antlr.Token, layout *layoutAnnotations) []byte {
 		}
 		//nolint:nestif // A source newline is either preserved, collapsed, or suppressed by literal layout.
 		if text == "\n" || text == "\r\n" {
-			if !layout.compositeNewlines[index] && !layout.sequenceNewlines[index] {
+			if layout.declarationNewlines[index] || (!layout.compositeNewlines[index] && !layout.sequenceNewlines[index]) {
 				if len(line) > 0 {
 					flush()
 				} else if previousWasNewline {
@@ -132,6 +133,12 @@ func renderTokens(tokens []antlr.Token, layout *layoutAnnotations) []byte {
 // logical line in its compact form. Multiline literals are deliberately
 // decided as a unit: once one does not fit, each item is rendered vertically.
 func compositeExceedsLineWidth(line []indexedToken, composite compositeLayout, layout *layoutAnnotations, depth int) bool {
+	for index := composite.start; index <= composite.stop; index++ {
+		if layout.declarationOpens[index] {
+			return true
+		}
+	}
+
 	flat := append(append([]indexedToken(nil), line...), layout.compactTokens(composite.start, composite.stop)...)
 	indent := strings.Repeat("\t", depth-leadingClosers(line, layout))
 	return utf8.RuneCountInString(indent)+utf8.RuneCountInString(renderLine(flat, layout)) > maxLineLength
@@ -307,6 +314,7 @@ type layoutAnnotations struct {
 	sequences              map[int]compositeLayout
 	declarationOpens       map[int]bool
 	declarationCloses      map[int]bool
+	declarationNewlines    map[int]bool
 	importBlocks           map[int]importBlock
 	tokens                 []antlr.Token
 }
@@ -331,6 +339,7 @@ func newLayoutAnnotations(tokens []antlr.Token) *layoutAnnotations {
 		sequences:              make(map[int]compositeLayout),
 		declarationOpens:       make(map[int]bool),
 		declarationCloses:      make(map[int]bool),
+		declarationNewlines:    make(map[int]bool),
 		importBlocks:           make(map[int]importBlock),
 	}
 }
@@ -616,6 +625,12 @@ func (l *layoutAnnotations) markDeclarationBlock(ctx antlr.ParserRuleContext) {
 	}
 	l.declarationOpens[open] = true
 	l.declarationCloses[closing] = true
+	for index := open; index <= closing; index++ {
+		text := l.tokens[index].GetText()
+		if text == "\n" || text == "\r\n" {
+			l.declarationNewlines[index] = true
+		}
+	}
 }
 
 // firstToken returns the first matching token index in one parser-rule context.

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -1,6 +1,9 @@
 package formatter
 
 import (
+	"bytes"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,4 +55,61 @@ func TestFormatNormalizesCRLF(t *testing.T) {
 	got, err := Format([]byte("def Main(start any) (stop any) {\r\n:start->:stop\r\n}\r\n"))
 	require.Nil(t, err)
 	require.Equal(t, []byte("def Main(start any) (stop any) {\n\t:start -> :stop\n}\n"), got)
+}
+
+func TestFormatCorpus(t *testing.T) {
+	roots := []string{
+		"../../std",
+		"../../examples",
+		"../../e2e",
+		"../../internal/compiler/parser/smoke_test/happypath",
+	}
+
+	for _, path := range roots {
+		require.NoError(t, formatCorpusRoot(path))
+	}
+}
+
+func formatCorpusRoot(path string) error {
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return fmt.Errorf("open corpus root %s: %w", path, err)
+	}
+
+	walkErr := fs.WalkDir(root.FS(), ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(name) != ".neva" {
+			return nil
+		}
+		return formatCorpusFile(root, path, name)
+	})
+	closeErr := root.Close()
+	if walkErr != nil {
+		return fmt.Errorf("walk corpus root %s: %w", path, walkErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close corpus root %s: %w", path, closeErr)
+	}
+	return nil
+}
+
+func formatCorpusFile(root *os.Root, rootPath, name string) error {
+	source, err := root.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("read %s/%s: %w", rootPath, name, err)
+	}
+	formatted, formatErr := Format(source)
+	if formatErr != nil {
+		return fmt.Errorf("format %s/%s: %w", rootPath, name, formatErr)
+	}
+	again, reformatErr := Format(formatted)
+	if reformatErr != nil {
+		return fmt.Errorf("reformat %s/%s: %w", rootPath, name, reformatErr)
+	}
+	if !bytes.Equal(formatted, again) {
+		return fmt.Errorf("format %s/%s is not idempotent", rootPath, name)
+	}
+	return nil
 }

--- a/pkg/formatter/testdata/declaration_blocks/golden.neva
+++ b/pkg/formatter/testdata/declaration_blocks/golden.neva
@@ -19,3 +19,10 @@ type ManyUnion union {
 	First string
 	Second string
 }
+
+type Wrapper vec<
+	union {
+		First
+		Second
+	},
+>

--- a/pkg/formatter/testdata/declaration_blocks/input.neva
+++ b/pkg/formatter/testdata/declaration_blocks/input.neva
@@ -11,3 +11,6 @@ type OneUnion union { Value string }
 
 type ManyUnion union { First string
 Second string }
+
+type Wrapper vec<union { First
+Second }>

--- a/pkg/formatter/testdata/imports_leading_comment/golden.neva
+++ b/pkg/formatter/testdata/imports_leading_comment/golden.neva
@@ -1,0 +1,10 @@
+// Selects one matching branch.
+
+import {
+	fmt
+	streams
+}
+
+def Main(start any) (stop any) {
+	:start -> :stop
+}

--- a/pkg/formatter/testdata/imports_leading_comment/input.neva
+++ b/pkg/formatter/testdata/imports_leading_comment/input.neva
@@ -1,0 +1,10 @@
+// Selects one matching branch.
+
+import {
+	streams
+	fmt
+}
+
+def Main(start any) (stop any) {
+	:start -> :stop
+}


### PR DESCRIPTION
## Summary
- add idempotence coverage for all Neva source in std, examples, e2e, and parser happy-path fixtures
- preserve canonical import spacing after leading comments
- keep nested struct and union type declarations structural when type arguments are laid out vertically

## Validation
- go test ./internal/compiler/parser/... ./pkg/formatter
- golangci-lint run ./pkg/formatter ./internal/compiler/parser/...