### PR TITLE
Add neva fmt command and formatter documentation

### DIFF
--- a/docs/user/qna.md
+++ b/docs/user/qna.md
@@ -344,3 +344,17 @@ public interface or needs a broader migration is a refactoring or language
 rule, not a lint diagnostic. In particular, existing named single-port
 interfaces are not silently rewritten; new interfaces should omit those names
 to preserve structural compatibility.
+
+## Which style-guide rules can the formatter enforce?
+
+The formatter owns local syntax and layout rules with one unambiguous output:
+indentation, whitespace, line breaks, trailing commas in vertical sequences,
+the block layout of non-empty struct and union declarations, and import order
+and grouping. It also chooses between compact and vertical layouts for
+comma-separated forms according to the 80-character rule, but only where the
+grammar provides a safe break.
+
+It deliberately leaves semantic style rules to `neva lint`. Those include
+names, documentation, component size, and whether a node or interface port
+name can be omitted. Deciding the last rule requires resolving the component's
+interface, so it cannot be a file-local formatting operation.


### PR DESCRIPTION
## Summary

- add the first-party `neva fmt` command over the syntax-only formatter
- support stdin, files, deterministic recursive directories, `-w`, `-d`, `-l`, `-check`, and `-e`
- write `-w` changes atomically while preserving permissions
- define CLI exit codes and document the command, boundaries, and directory skip-list
- clarify formatter versus lint/refactoring policy and record the RFC amendment in #1171

## Validation

- `go test ./internal/cli ./cmd/neva ./pkg/formatter ./internal/compiler/parser/...` — 108 passed
- `golangci-lint run ./cmd/neva ./internal/cli ./pkg/formatter ./internal/compiler/parser/...` — 0 issues
- built binary: `fmt -check` exits 1 and conflicting output modes exit 2

The local repository-wide pre-push lint is not representative: it traverses an unrelated sibling worktree and reports its existing issues. GitHub CI is authoritative for this PR.