### PR TITLE
Clean up bytes round-trip test output

### DIFF
--- a/e2e/io_bytes_roundtrip/e2e_test.go
+++ b/e2e/io_bytes_roundtrip/e2e_test.go
@@ -1,6 +1,9 @@
 package test
 
 import (
+	"errors"
+	"io/fs"
+	"os"
 	"testing"
 
 	"github.com/nevalang/neva/pkg/e2e"
@@ -8,6 +11,13 @@ import (
 )
 
 func Test(t *testing.T) {
+	t.Cleanup(func() {
+		err := os.Remove("bytes_roundtrip.txt")
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("remove round-trip output: %v", err)
+		}
+	})
+
 	out, _ := e2e.Run(t, []string{"run", "main"})
 	require.Equal(t, "Hello, bytes!\n", out)
 }


### PR DESCRIPTION
Ensures the io_bytes_roundtrip e2e test removes its generated bytes_roundtrip.txt file after every run.\n\nValidation:\n- go test ./e2e/io_bytes_roundtrip\n- golangci-lint run ./e2e/io_bytes_roundtrip