### PR TITLE
Skip CI for non-code pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.codex/**'
+      - '.vscode/**'
+      - 'assets/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.codex/**'
+      - '.vscode/**'
+      - 'assets/**'
 
 jobs:
 


### PR DESCRIPTION
## What changed

Skip the `test` and `lint` workflows for pull requests that modify only Markdown files, `.codex/**`, `.vscode/**`, or `assets/**`.

Pushes to `main` remain unfiltered, and workflow files are not ignored.

## Why

These paths are not consumed by the current build or CI jobs, so running the Go test, lint, vulnerability, and installer checks for them provides no signal.

## Validation

- `actionlint .github/workflows/test.yml .github/workflows/lint.yml`
- YAML parse check
- `git diff --check`
- `lefthook run pre-commit`
- `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)

The repository-wide pre-push lint reports existing findings outside this PR; its changed-lines mode is clean.